### PR TITLE
Allow access to all functions via `latexify` and kwargs.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 LaTeXStrings 0.3.0
 Requires 0.4.3
+MacroTools 0.4.0

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,9 +10,11 @@ This package supplies functionality for latexifying objects of the following typ
 - Numbers (including rational and complex),
 - Missings' Missing type,
 - Symbols,
-- Symbolic expressions from SymEngine.jl.
+- Symbolic expressions from SymEngine.jl,
+- Any shape of array containing a mix of any of the above types,
+- ParameterizedFunctions from DifferentialEquations.jl,
+- ReactionNetworks from DifferentialEquations.jl
 
-Along with any shape of array which contains elements of the above types.
 
 Example:
 ```julia-repl
@@ -27,6 +29,19 @@ which renders as
 \begin{equation\*}
 \frac{x}{2 \cdot k_{1} + x^{2}}
 \end{equation\*}
+
+## Supported output
+
+Latexify has support for generating a range of different LaTeX environments. The main function of the package, `latexify()`, tries to infer what environment you need. However, you can override this by passing the keyword argument `env = `. The following environments are available:
+
+
+| environment | `env= ` |
+| ------ | ---- | --- |
+| no env | `:raw` | Latexifies an object and returns a ``\LaTeX`` formatted string. If the input is an array it will be recursed and all its elements latexified. This function does not surround the resulting string in any ``\LaTeX`` environments.
+| Inline | `:inline` | latexify the input and surround it with $$ for inline rendering. |
+| Align | `:align` | Latexifies input and surrounds it with an align environment. Useful for systems of equations and such fun stuff. |
+| Array | `:array` |
+
 
 ## Functions, at a glance
 

--- a/docs/src/tutorials/latexify.md
+++ b/docs/src/tutorials/latexify.md
@@ -55,4 +55,4 @@ z =& \frac{1}{2} \\\\
 \end{align}
 
 
-If you input a ParameterizedFunction or a ReactionNetwork from the DifferentialEquations.jl you will also get an align environment. For more on this, have a look on their respective sections.
+If you input a ParameterizedFunction or a ReactionNetwork from DifferentialEquations.jl you will also get an align environment. For more on this, have a look on their respective sections.

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -4,11 +4,19 @@ using Requires
 using LaTeXStrings
 using Base.Markdown
 
-export latexify, latexarray, latexalign, latexraw, latexinline, latextabular, copy_to_clipboard, mdtable, md
+export latexify, md, copy_to_clipboard, auto_display
+
+## Allow some backwards compatibility until its time to deprecate.
+export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
 
 COPY_TO_CLIPBOARD = false
 function copy_to_clipboard(x::Bool)
     global COPY_TO_CLIPBOARD = x
+end
+
+AUTO_DISPLAY = false
+function auto_display(x::Bool)
+    global AUTO_DISPLAY = x
 end
 
 include("latexraw.jl")

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -3,6 +3,7 @@ module Latexify
 using Requires
 using LaTeXStrings
 using Base.Markdown
+using MacroTools: postwalk
 
 export latexify, md, copy_to_clipboard, auto_display
 

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -29,4 +29,5 @@ include("latextabular.jl")
 
 include("md.jl")
 include("mdtable.jl")
+include("mdtext.jl")
 end

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -42,7 +42,7 @@ function latexalign end
 
 function latexalign(arr::AbstractMatrix; separator=" =& ", md=false, starred=false)
     (rows, columns) = size(arr)
-    eol = md ? "\\\\\\\\ \n" : "\\\\ \n"
+    eol = md ? " \\\\\\\\ \n" : " \\\\ \n"
     arr = latexraw(arr)
 
     str = "\\begin{align$(starred ? "*" : "")}\n"

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -16,7 +16,7 @@ function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false,
     starred=false)
     transpose && (arr = permutedims(arr, [2,1]))
     (rows, columns) = size(arr)
-    eol = md ? "\\\\\\\\ \n" : "\\\\ \n"
+    eol = md ? " \\\\\\\\ \n" : " \\\\ \n"
 
     str = "\\begin{equation$(starred ? "*" : "")}\n"
     str *= "\\left[\n"

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -36,3 +36,4 @@ end
 
 latexarray(vec::AbstractVector; kwargs...) = latexarray(hcat(vec...); kwargs...)
 latexarray(args::AbstractArray...; kwargs...) = latexarray(hcat(args...); kwargs...)
+latexarray(ass::Associative) = latexarray(collect(keys(ass)), collect(values(ass)))

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -12,22 +12,25 @@ latexarray(arr)
 "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2\\\\ \n3 & 4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
 ```
 """
-function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false)
+function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false, md=false,
+    starred=false)
     transpose && (arr = permutedims(arr, [2,1]))
     (rows, columns) = size(arr)
-    str = "\\begin{equation}\n"
+    eol = md ? "\\\\\\\\ \n" : "\\\\ \n"
+
+    str = "\\begin{equation$(starred ? "*" : "")}\n"
     str *= "\\left[\n"
     str *= "\\begin{array}{" * "$(adjustment)"^columns * "}\n"
 
     arr = latexraw(arr)
     for i=1:rows, j=1:columns
         str *= arr[i,j]
-        j==columns ? (str *= "\\\\ \n") : (str *= " & ")
+        j==columns ? (str *= eol) : (str *= " & ")
     end
 
     str *= "\\end{array}\n"
     str *= "\\right]\n"
-    str *= "\\end{equation}\n"
+    str *= "\\end{equation$(starred ? "*" : "")}\n"
     latexstr = LaTeXString(str)
     COPY_TO_CLIPBOARD && clipboard(latexstr)
     return latexstr
@@ -36,4 +39,4 @@ end
 
 latexarray(vec::AbstractVector; kwargs...) = latexarray(hcat(vec...); kwargs...)
 latexarray(args::AbstractArray...; kwargs...) = latexarray(hcat(args...); kwargs...)
-latexarray(ass::Associative) = latexarray(collect(keys(ass)), collect(values(ass)))
+latexarray(ass::Associative; kwargs...) = latexarray(collect(keys(ass)), collect(values(ass)); kwargs...)

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -35,3 +35,4 @@ end
 
 
 latexarray(vec::AbstractVector; kwargs...) = latexarray(hcat(vec...); kwargs...)
+latexarray(args::AbstractArray...; kwargs...) = latexarray(hcat(args...); kwargs...)

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -34,6 +34,7 @@ This determines the default behaviour of `latexify()` for different inputs.
 """
 get_latex_function(args...) = latexinline
 get_latex_function(args::AbstractArray...) = latexarray
+get_latex_function(args::Associative) = latexarray
 
 
 function get_latex_function(x::AbstractArray{T}) where T <: AbstractArray

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -16,6 +16,7 @@ function infer_output(env, args...)
         env == :table && return latextabular
         env == :raw && return latexraw
         env == :array && return latexarray
+        env == :align && return latexalign
 
         error("The environment $env is not defined.")
     end
@@ -51,7 +52,7 @@ get_latex_function(lhs::AbstractVector, rhs::AbstractVector) = latexalign
 
 @require DiffEqBase begin
     get_latex_function(ode::DiffEqBase.AbstractParameterizedFunction) = latexalign
-    get_latex_function(r::DiffEqBase.AbstractReactionNetwork; kwargs...) = latexalign
+    get_latex_function(r::DiffEqBase.AbstractReactionNetwork) = latexalign
 
     function get_latex_function(x::AbstractArray{T}) where T <: DiffEqBase.AbstractParameterizedFunction
         return latexalign

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -2,16 +2,22 @@ function latexify(args...; env::Symbol=:auto, kwargs...)
     latex_function = infer_output(env, args...)
 
     result = latex_function(args...; kwargs...)
+
     COPY_TO_CLIPBOARD && clipboard(result)
+    AUTO_DISPLAY && display(result)
     return result
 end
 
 
 function infer_output(env, args...)
     if env != :auto
-        funcname = Symbol("latex$env")
-        isdefined(funcname) || error("The environment $env is not defined.")
-        return eval(:($funcname))
+        env == :inline && return latexinline
+        env == :tabular && return latextabular
+        env == :table && return latextabular
+        env == :raw && return latexraw
+        env == :array && return latexarray
+
+        error("The environment $env is not defined.")
     end
 
     latex_function = get_latex_function(args...)

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -58,6 +58,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray)
     op == :acsc && return "\\mathrm{arccsc}\\left( $(args[2]) \\right)"
     op == :csch && return "\\mathrm{csch}\\left( $(args[2]) \\right)"
     op == :acsch && return "\\mathrm{arccsch}\\left( $(args[2]) \\right)"
+    op == :gamma && return "\\Gamma\\left( $(args[2]) \\right)"
     op == :sqrt && return "\\$op{$(args[2])}"
     op == :abs && return "\\left\\|$(args[2])\\right\\|"
     op == :exp && return "e^{$(args[2])}"

--- a/src/latextabular.jl
+++ b/src/latextabular.jl
@@ -19,3 +19,4 @@ end
 
 
 latextabular(vec::AbstractVector; kwargs...) = latextabular(hcat(vec...); kwargs...)
+latextabular(vectors::AbstractVector...; kwargs...) = latextabular(hcat(vectors...); kwargs...)

--- a/src/md.jl
+++ b/src/md.jl
@@ -18,6 +18,7 @@ function infer_md_output(env, args...)
         env == :text && return mdtext
         env == :align && return mdalign
         env == :array && return mdarray
+        env == :inline && return latexinline
         error("The MD environment $env is not defined.")
     end
 

--- a/src/md.jl
+++ b/src/md.jl
@@ -9,9 +9,6 @@ function md(args...; env=:auto, kwargs...)
     return m
 end
 
-# md(v::AbstractArray...; kwargs...) = mdtable(v...; kwargs...)
-# md(d::Associative; kwargs...) = mdtable(d; kwargs...)
-
 
 function infer_md_output(env, args...)
     if env != :auto

--- a/src/md.jl
+++ b/src/md.jl
@@ -9,11 +9,15 @@ function md(args...; env=:auto, kwargs...)
     return m
 end
 
+mdalign(args...; kwargs...) = latexalign(args...; md=true, kwargs...)
+mdarray(args...; kwargs...) = latexarray(args...; md=true, kwargs...)
 
 function infer_md_output(env, args...)
     if env != :auto
         env == :table && return mdtable
         env == :text && return mdtext
+        env == :align && return mdalign
+        env == :array && return mdarray
         error("The MD environment $env is not defined.")
     end
 
@@ -32,3 +36,11 @@ This determines the default behaviour of `md()` for different inputs.
 get_md_function(args...) = mdtext
 get_md_function(args::AbstractArray...) = mdtable
 get_md_function(args::Associative) = mdtable
+
+@require DiffEqBase begin
+    get_md_function(args::DiffEqBase.AbstractParameterizedFunction) = mdalign
+    get_md_function(args::DiffEqBase.AbstractReactionNetwork) = mdalign
+    function get_md_function(x::AbstractArray{T}) where T <: DiffEqBase.AbstractParameterizedFunction
+        return mdalign
+    end
+end

--- a/src/md.jl
+++ b/src/md.jl
@@ -1,10 +1,37 @@
 
 
-function md(s::String)
-    m = Markdown.parse(s)
+function md(args...; env=:auto, kwargs...)
+    md_function = infer_md_output(env, args...)
+
+    m = md_function(args...; kwargs...)
     COPY_TO_CLIPBOARD && clipboard(m)
+    AUTO_DISPLAY && display(m)
     return m
 end
 
-md(v::AbstractArray...; kwargs...) = mdtable(v...; kwargs...)
-md(d::Associative; kwargs...) = mdtable(d; kwargs...)
+# md(v::AbstractArray...; kwargs...) = mdtable(v...; kwargs...)
+# md(d::Associative; kwargs...) = mdtable(d; kwargs...)
+
+
+function infer_md_output(env, args...)
+    if env != :auto
+        env == :table && return mdtable
+        env == :text && return mdtext
+        error("The MD environment $env is not defined.")
+    end
+
+    md_function = get_md_function(args...)
+
+    return md_function
+end
+
+"""
+    get_md_function(args...)
+
+Use overloading to determine what MD output to generate.
+
+This determines the default behaviour of `md()` for different inputs.
+"""
+get_md_function(args...) = mdtext
+get_md_function(args::AbstractArray...) = mdtable
+get_md_function(args::Associative) = mdtable

--- a/src/mdtext.jl
+++ b/src/mdtext.jl
@@ -1,0 +1,5 @@
+
+function mdtext(s::String)
+    m = Markdown.parse(s)
+    return m
+end

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -12,12 +12,7 @@ g = @ode_def test2 begin
     dz = p_z
 end p_x d_x d_x_y p_y d_y p_z
 
-test_results = []
-
-push!(test_results, latexalign(["d$x/dt" for x in f.syms], f.funcs) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n")
-push!(test_results, latexalign(f) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n")
-push!(test_results, latexalign(f, field=:symfuncs) == "\\begin{align}\n\\frac{dx}{dt} =& - x + \\frac{y}{c_{1}} \\\\ \n\\frac{dy}{dt} =& - y + x^{c_{2}} \\\\ \n\\end{align}\n")
-push!(test_results, latexalign([f,g]) == "\\begin{align}\n\\frac{dx}{dt}  &=  \\frac{y}{c_{1}} - x  &  \\frac{dx}{dt}  &=  p_{x} - d_{x} \\cdot x - d_{x\\_y} \\cdot y \\cdot x  &  \\\\ \n\\frac{dy}{dt}  &=  x^{c_{2}} - y  &  \\frac{dy}{dt}  &=  p_{y} - d_{y} \\cdot y  &  \\\\ \n  &    &  \\frac{dz}{dt}  &=  p_{z} \\cdot 1  &  \\\\ \n\\end{align}\n")
-
-println("latexalign_test successes: \n", test_results)
-all(test_results)
+@test latexalign(["d$x/dt" for x in f.syms], f.funcs) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n"
+@test latexalign(f) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n"
+@test latexalign(f, field=:symfuncs) == "\\begin{align}\n\\frac{dx}{dt} =& - x + \\frac{y}{c_{1}} \\\\ \n\\frac{dy}{dt} =& - y + x^{c_{2}} \\\\ \n\\end{align}\n"
+@test latexalign([f,g]) == "\\begin{align}\n\\frac{dx}{dt}  &=  \\frac{y}{c_{1}} - x  &  \\frac{dx}{dt}  &=  p_{x} - d_{x} \\cdot x - d_{x\\_y} \\cdot y \\cdot x  &  \\\\ \n\\frac{dy}{dt}  &=  x^{c_{2}} - y  &  \\frac{dy}{dt}  &=  p_{y} - d_{y} \\cdot y  &  \\\\ \n  &    &  \\frac{dz}{dt}  &=  p_{z} \\cdot 1  &  \\\\ \n\\end{align}\n"

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -1,11 +1,7 @@
 using Latexify
 
-test_results = []
 arr = [1 2; 3 4]
-push!(test_results, latexarray(arr) == "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2\\\\ \n3 & 4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n")
+@test latexarray(arr) == "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2\\\\ \n3 & 4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
 
 arr = [1,2,:(x/y),4]
-push!(test_results, latexarray(arr, transpose=true) == "\\begin{equation}\n\\left[\n\\begin{array}{c}\n1\\\\ \n2\\\\ \n\\frac{x}{y}\\\\ \n4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n")
-
-println("latexarray_test successes: \n", test_results)
-all(test_results)
+@test latexarray(arr, transpose=true) == "\\begin{equation}\n\\left[\n\\begin{array}{c}\n1\\\\ \n2\\\\ \n\\frac{x}{y}\\\\ \n4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -1,7 +1,7 @@
 using Latexify
 
 arr = [1 2; 3 4]
-@test latexarray(arr) == "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2\\\\ \n3 & 4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
+@test latexarray(arr) == "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2 \\\\ \n3 & 4 \\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
 
 arr = [1,2,:(x/y),4]
-@test latexarray(arr, transpose=true) == "\\begin{equation}\n\\left[\n\\begin{array}{c}\n1\\\\ \n2\\\\ \n\\frac{x}{y}\\\\ \n4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
+@test latexarray(arr, transpose=true) == "\\begin{equation}\n\\left[\n\\begin{array}{c}\n1 \\\\ \n2 \\\\ \n\\frac{x}{y} \\\\ \n4 \\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -10,3 +10,7 @@ f = @ode_def feedback begin
 ## Todo: write some actual tests.
 
 test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
+
+for env in [:raw, :inline, :array, :align, :tabular]
+    @test latexify(test_array; env=env) == eval(parse("latex$env(test_array)"))
+end

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -9,7 +9,4 @@ f = @ode_def feedback begin
 
 ## Todo: write some actual tests.
 
-test_results = []
 test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
-
-true

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -7,10 +7,10 @@ f = @ode_def feedback begin
     dy = x^c_2 - y
     end c_1 c_2
 
-## Todo: write some actual tests.
-
 test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
 
 for env in [:raw, :inline, :array, :align, :tabular]
     @test latexify(test_array; env=env) == eval(parse("latex$env(test_array)"))
 end
+
+@test latexify(f; starred = true) == "\\begin{align*}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align*}\n"

--- a/test/latexinline_test.jl
+++ b/test/latexinline_test.jl
@@ -1,11 +1,8 @@
 using Latexify
 using LaTeXStrings
 
-test_results = []
 test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
-push!(test_results, latexinline(test_array) == [
+@test latexinline(test_array) == [
     L"$\frac{x}{y} \cdot d$"                          L"$x$"         ;
     L"$\left( t_{sub\_sub} - x \right)^{2 \cdot p}$"  L"$\frac{3}{4}$"
-    ])
-
-all(test_results)
+    ]

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -1,54 +1,50 @@
 
 using Latexify
 using ParameterizedFunctions
-test_results = []
 
 str = "2*x^2 - y/c_2"
 exp = :(2*x^2 - y/c_2)
 
 desired_output = "2 \\cdot x^{2} - \\frac{y}{c_{2}}"
 
-push!(test_results, latexraw(str) == latexraw(exp))
-push!(test_results, latexraw(exp) == desired_output)
+@test latexraw(str) == latexraw(exp)
+@test latexraw(exp) == desired_output
 
 array_test = [exp, str]
-push!(test_results, all(latexraw(array_test) .== desired_output))
+@test all(latexraw(array_test) .== desired_output)
 
-push!(test_results, latexraw(:y_c_a) == "y_{c\\_a}")
-push!(test_results, latexraw(1.0) == "1.0")
-push!(test_results, latexraw(1.00) == "1.0")
-push!(test_results, latexraw(1) == "1")
-push!(test_results, latexraw(:(log10(x))) == "\\log_{10}\\left( x \\right)")
-push!(test_results, latexraw(:(sin(x))) ==  "\\sin\\left( x \\right)")
-push!(test_results, latexraw(:(asin(x))) ==  "\\arcsin\\left( x \\right)")
-push!(test_results, latexraw(:(asinh(x))) ==  "\\mathrm{arcsinh}\\left( x \\right)")
-push!(test_results, latexraw(:(sinc(x))) ==  "\\mathrm{sinc}\\left( x \\right)")
-push!(test_results, latexraw(:(acos(x))) ==  "\\arccos\\left( x \\right)")
-push!(test_results, latexraw(:(acosh(x))) ==  "\\mathrm{arccosh}\\left( x \\right)")
-push!(test_results, latexraw(:(cosc(x))) ==  "\\mathrm{cosc}\\left( x \\right)")
-push!(test_results, latexraw(:(atan(x))) ==  "\\arctan\\left( x \\right)")
-push!(test_results, latexraw(:(atan2(x))) ==  "\\arctan\\left( x \\right)")
-push!(test_results, latexraw(:(atanh(x))) ==  "\\mathrm{arctanh}\\left( x \\right)")
-push!(test_results, latexraw(:(acot(x))) ==  "\\mathrm{arccot}\\left( x \\right)")
-push!(test_results, latexraw(:(acoth(x))) ==  "\\mathrm{arccoth}\\left( x \\right)")
-push!(test_results, latexraw(:(asec(x))) ==  "\\mathrm{arcsec}\\left( x \\right)")
-push!(test_results, latexraw(:(sech(x))) ==  "\\mathrm{sech}\\left( x \\right)")
-push!(test_results, latexraw(:(asech(x))) ==  "\\mathrm{arcsech}\\left( x \\right)")
-push!(test_results, latexraw(:(acsc(x))) ==  "\\mathrm{arccsc}\\left( x \\right)")
-push!(test_results, latexraw(:(csch(x))) ==  "\\mathrm{csch}\\left( x \\right)")
-push!(test_results, latexraw(:(acsch(x))) ==  "\\mathrm{arccsch}\\left( x \\right)")
-push!(test_results, latexraw(:(f(x))) ==  "\\mathrm{f}\\left( x \\right)")
-push!(test_results, latexraw("x = 4*y") == "x = 4 \\cdot y")
-push!(test_results, latexraw(:(sqrt(x))) == "\\sqrt{x}")
-push!(test_results, latexraw(complex(1,-1)) == "1-1\\textit{i}")
-push!(test_results, latexraw(1//2) == "\\frac{1}{2}")
-push!(test_results, latexraw(Missing()) == "\\textrm{NA}")
+@test latexraw(:y_c_a) == "y_{c\\_a}"
+@test latexraw(1.0) == "1.0"
+@test latexraw(1.00) == "1.0"
+@test latexraw(1) == "1"
+@test latexraw(:(log10(x))) == "\\log_{10}\\left( x \\right)"
+@test latexraw(:(sin(x))) ==  "\\sin\\left( x \\right)"
+@test latexraw(:(asin(x))) ==  "\\arcsin\\left( x \\right)"
+@test latexraw(:(asinh(x))) ==  "\\mathrm{arcsinh}\\left( x \\right)"
+@test latexraw(:(sinc(x))) ==  "\\mathrm{sinc}\\left( x \\right)"
+@test latexraw(:(acos(x))) ==  "\\arccos\\left( x \\right)"
+@test latexraw(:(acosh(x))) ==  "\\mathrm{arccosh}\\left( x \\right)"
+@test latexraw(:(cosc(x))) ==  "\\mathrm{cosc}\\left( x \\right)"
+@test latexraw(:(atan(x))) ==  "\\arctan\\left( x \\right)"
+@test latexraw(:(atan2(x))) ==  "\\arctan\\left( x \\right)"
+@test latexraw(:(atanh(x))) ==  "\\mathrm{arctanh}\\left( x \\right)"
+@test latexraw(:(acot(x))) ==  "\\mathrm{arccot}\\left( x \\right)"
+@test latexraw(:(acoth(x))) ==  "\\mathrm{arccoth}\\left( x \\right)"
+@test latexraw(:(asec(x))) ==  "\\mathrm{arcsec}\\left( x \\right)"
+@test latexraw(:(sech(x))) ==  "\\mathrm{sech}\\left( x \\right)"
+@test latexraw(:(asech(x))) ==  "\\mathrm{arcsech}\\left( x \\right)"
+@test latexraw(:(acsc(x))) ==  "\\mathrm{arccsc}\\left( x \\right)"
+@test latexraw(:(csch(x))) ==  "\\mathrm{csch}\\left( x \\right)"
+@test latexraw(:(acsch(x))) ==  "\\mathrm{arccsch}\\left( x \\right)"
+@test latexraw(:(f(x))) ==  "\\mathrm{f}\\left( x \\right)"
+@test latexraw("x = 4*y") == "x = 4 \\cdot y"
+@test latexraw(:(sqrt(x))) == "\\sqrt{x}"
+@test latexraw(complex(1,-1)) == "1-1\\textit{i}"
+@test latexraw(1//2) == "\\frac{1}{2}"
+@test latexraw(Missing()) == "\\textrm{NA}"
 
 f = @ode_def feedback begin
     dx = y/c_1 - x
     dy = x^c_2 - y
 end c_1 c_2
-push!(test_results, latexraw(f) == ["\\frac{dx}{dt} = \\frac{y}{c_{1}} - x", "\\frac{dy}{dt} = x^{c_{2}} - y"])
-
-println("latexraw_test successes: \n", test_results)
-all(test_results)
+@test latexraw(f) == ["\\frac{dx}{dt} = \\frac{y}{c_{1}} - x", "\\frac{dy}{dt} = x^{c_{2}} - y"]

--- a/test/mdtable_test.jl
+++ b/test/mdtable_test.jl
@@ -4,7 +4,6 @@ M = vcat(hcat(arr...), hcat(arr...))
 head = ["col$i" for i in 1:size(M, 2)]
 side = ["row$i" for i in 1:size(M, 1)]
 
-@testset "mdtable()" begin
 
 @test mdtable(arr) == Markdown.md"
 | $\frac{x}{y - 1}$ |
@@ -93,5 +92,3 @@ side = ["row$i" for i in 1:size(M, 1)]
 | col4 |           $x - y$ |           $x - y$ |
 | col5 |            $symb$ |            $symb$ |
 "
-
-end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,17 +9,9 @@ using Base.Test
 
 # Run tests
 
-tic()
-println("Test latexraw function")
-@time @test include("latexraw_test.jl")
-println("Test latexify function")
-@time @test include("latexify_test.jl")
-println("Test latexalign function")
-@time @test include("latexalign_test.jl")
-println("Test latexarray function")
-@time @test include("latexarray_test.jl")
-println("Test latexinline function")
-@time @test include("latexinline_test.jl")
-println("Test mdtable function")
-@time include("mdtable_test.jl")
-toc()
+@testset "latexify tests" begin include("latexify_test.jl") end
+@testset "latexraw tests" begin include("latexraw_test.jl") end
+@testset "latexalign tests" begin include("latexalign_test.jl") end
+@testset "latexarray tests" begin include("latexarray_test.jl") end
+@testset "latexinline tests" begin include("latexinline_test.jl") end
+@testset "mdtable tests" begin include("mdtable_test.jl") end


### PR DESCRIPTION
Admittedly, this merge is a bit of a mess (I have worked on too many things at once). But, the main feature that this provides is the ability of `latexify()` to handle all kinds of input, and for the user to be able to specify what output they want using a keyword argument.

previously:
```julia
latexarray([1,2,3])
```
now:
```julia
latexify([1,2,3]; env=:array)
```

As before, `latexify` will try to infer the desired output based on the input. But now you can override the defaults. 


This merge brings some additional changes (which really should have been developed in separate branches): 
-  Make the tests actually use Base.Test.
-  Add support for dicts with latexarray.
-  Add ability to generate starred array and align environments (`\begin{align*}....).
-  Add kwarg `bracket=false` to aligns of ParameterizedFunctions and ReactionNetworks. This surrounds the variable symbols with square brackets and is meant to denote concentrations. 

I still have not created any good documentation for this, and I will need to add that before a new release. 

