### PR TITLE
Improve non-symbolic handling of reaction networks.

### DIFF
--- a/docs/src/tutorials/DiffEqBiological.md
+++ b/docs/src/tutorials/DiffEqBiological.md
@@ -1,6 +1,6 @@
 # Use with @reaction_network from DiffEqBiological.jl.
 
-Latexify.jl has methods for dealing with AbstractReactionNetworks. For more information regarding this DSL, turn to its [docs](http://docs.juliadiffeq.org/latest/models/biological.html). The latexify end of things are pretty simple: feed a reaction network to the `latexify` or `latexalign` functions (they do the same thing in this case) and let them do their magic.
+Latexify.jl has methods for dealing with AbstractReactionNetworks. For more information regarding this DSL, turn to its [docs](http://docs.juliadiffeq.org/latest/models/biological.html). The latexify end of things are pretty simple: feed a reaction network to `latexify()` and let it do its magic.
 
 ```julia
 using DiffEqBiological
@@ -18,40 +18,25 @@ end v_x k_x p_y d_x d_y r_b r_u
 
 latexify(rn)
 ```
+```math
 \begin{align}
-\frac{dx}{dt} =& - x \cdot d_{x} - x \cdot r_{b} + y \cdot r_{u} + \frac{y^{2} \cdot v_{x}}{k_{x}^{2} + y^{2}} \\\\
-\frac{dy}{dt} =& p_{y} + x \cdot r_{b} - y \cdot d_{y} - y \cdot r_{u} \\\\
+\frac{dx}{dt} =& \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} - d_{x} \cdot x - r_{b} \cdot x + r_{u} \cdot y \\
+\frac{dy}{dt} =& p_{y} - d_{y} \cdot y + r_{b} \cdot x - r_{u} \cdot y \\
 \end{align}
+```
 
 The method has a keyword for choosing between outputting the ODE or the noise term. While it is not obvious from the latexify output, the noise in the reaction network is correlated.
 
 ```julia
 latexify(rn; noise=true)
 ```
+
+```math
 \begin{align}
-\frac{dx}{dt} =& - \sqrt{x \cdot d_{x}} - \sqrt{x \cdot r_{b}} + \sqrt{y \cdot r_{u}} + \sqrt{\frac{y^{2} \cdot v_{x}}{k_{x}^{2} + y^{2}}} \\\\
-\frac{dy}{dt} =& \sqrt{p_{y}} + \sqrt{x \cdot r_{b}} - \sqrt{y \cdot d_{y}} - \sqrt{y \cdot r_{u}} \\\\
+\frac{dx}{dt} =& \sqrt{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} - \sqrt{d_{x} \cdot x} - \sqrt{r_{b} \cdot x} + \sqrt{r_{u} \cdot y} \\
+\frac{dy}{dt} =& \sqrt{p_{y}} - \sqrt{d_{y} \cdot y} + \sqrt{r_{b} \cdot x} - \sqrt{r_{u} \cdot y} \\
 \end{align}
-
-
-### Turning off the SymEngine magic
-
-SymEngine will be used by default to clean up the expressions. A disadvantage of this is that the order of the terms and the operations within the terms becomes unpredictable. You can therefore turn this symbolic magic off. The result has some ugly issues with $+ -1$, but the option is there, and here is how to use it:  
-```julia
-latexify(rn; symbolic=false)
 ```
-\begin{align}
-\frac{dx}{dt} =& \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} + -1 \cdot d_{x} \cdot x + -1 \cdot r_{b} \cdot x + r_{u} \cdot y \\\\
-\frac{dy}{dt} =& p_{y} + -1 \cdot d_{y} \cdot y + r_{b} \cdot x + -1 \cdot r_{u} \cdot y \\\\
-\end{align}
-
-```julia
-latexify(rn; noise=true, symbolic=false)
-```
-\begin{align}
-\frac{dx}{dt} =& \sqrt{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} + - \sqrt{d_{x} \cdot x} + - \sqrt{r_{b} \cdot x} + \sqrt{r_{u} \cdot y} \\\\
-\frac{dy}{dt} =& \sqrt{p_{y}} + - \sqrt{d_{y} \cdot y} + \sqrt{r_{b} \cdot x} + - \sqrt{r_{u} \cdot y} \\\\
-\end{align}
 
 
 ## Chemical arrow notation

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -198,7 +198,7 @@ function clean_subtractions(ex::Expr)
 
     ### Sort out the other terms
     for term in ex.args[3:end]
-        if length(term.args) >= 3 && term.args[1:2] == [:*, -1]
+        if term isa Expr && length(term.args) >= 3 && term.args[1:2] == [:*, -1]
             result = :($result - *($(term.args[3:end]...)))
         else
             result = :($result + $term)

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -42,7 +42,7 @@ function latexalign end
 
 function latexalign(arr::AbstractMatrix; separator=" =& ", md=false, starred=false)
     (rows, columns) = size(arr)
-    eol = md ? " \\\\\\\\ \n" : " \\\\ \n"
+    eol = md ? " \\\\\\\\\n" : " \\\\\n"
     arr = latexraw(arr)
 
     str = "\\begin{align$(starred ? "*" : "")}\n"

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -1,5 +1,7 @@
 using Latexify
 using ParameterizedFunctions
+using DiffEqBiological
+using Base.Test
 
 f = @ode_def feedback begin
     dx = y/c_1 - x
@@ -12,7 +14,30 @@ g = @ode_def test2 begin
     dz = p_z
 end p_x d_x d_x_y p_y d_y p_z
 
-@test latexalign(["d$x/dt" for x in f.syms], f.funcs) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n"
-@test latexalign(f) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align}\n"
-@test latexalign(f, field=:symfuncs) == "\\begin{align}\n\\frac{dx}{dt} =& - x + \\frac{y}{c_{1}} \\\\ \n\\frac{dy}{dt} =& - y + x^{c_{2}} \\\\ \n\\end{align}\n"
-@test latexalign([f,g]) == "\\begin{align}\n\\frac{dx}{dt}  &=  \\frac{y}{c_{1}} - x  &  \\frac{dx}{dt}  &=  p_{x} - d_{x} \\cdot x - d_{x\\_y} \\cdot y \\cdot x  &  \\\\ \n\\frac{dy}{dt}  &=  x^{c_{2}} - y  &  \\frac{dy}{dt}  &=  p_{y} - d_{y} \\cdot y  &  \\\\ \n  &    &  \\frac{dz}{dt}  &=  p_{z} \\cdot 1  &  \\\\ \n\\end{align}\n"
+@test latexalign(["d$x/dt" for x in f.syms], f.funcs) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\\n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\\n\\end{align}\n"
+@test latexalign(f) == "\\begin{align}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\\n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\\n\\end{align}\n"
+@test latexalign(f, field=:symfuncs) == "\\begin{align}\n\\frac{dx}{dt} =& - x + \\frac{y}{c_{1}} \\\\\n\\frac{dy}{dt} =& - y + x^{c_{2}} \\\\\n\\end{align}\n"
+@test latexalign([f,g]) == "\\begin{align}\n\\frac{dx}{dt}  &=  \\frac{y}{c_{1}} - x  &  \\frac{dx}{dt}  &=  p_{x} - d_{x} \\cdot x - d_{x\\_y} \\cdot y \\cdot x  &  \\\\\n\\frac{dy}{dt}  &=  x^{c_{2}} - y  &  \\frac{dy}{dt}  &=  p_{y} - d_{y} \\cdot y  &  \\\\\n  &    &  \\frac{dz}{dt}  &=  p_{z} \\cdot 1  &  \\\\\n\\end{align}\n"
+
+
+
+@reaction_func hill2(x, v, k) = v*x^2/(k^2 + x^2)
+
+rn = @reaction_network MyRnType begin
+  hill2(y, v_x, k_x), 0 --> x
+  p_y, 0 --> y
+  (d_x, d_y), (x, y) --> 0
+  (r_b, r_u), x ↔ y
+end v_x k_x p_y d_x d_y r_b r_u
+
+@test latexalign(rn).s == raw"\begin{align}
+\frac{dx}{dt} =& \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} - d_{x} \cdot x - r_{b} \cdot x + r_{u} \cdot y \\
+\frac{dy}{dt} =& p_{y} - d_{y} \cdot y + r_{b} \cdot x - r_{u} \cdot y \\
+\end{align}
+"
+
+@test latexalign(rn; symbolic=true).s == raw"\begin{align}
+\frac{dx}{dt} =& - x \cdot d_{x} - x \cdot r_{b} + y \cdot r_{u} + \frac{y^{2} \cdot v_{x}}{k_{x}^{2} + y^{2}} \\
+\frac{dy}{dt} =& p_{y} + x \cdot r_{b} - y \cdot d_{y} - y \cdot r_{u} \\
+\end{align}
+"

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -13,4 +13,4 @@ for env in [:raw, :inline, :array, :align, :tabular]
     @test latexify(test_array; env=env) == eval(parse("latex$env(test_array)"))
 end
 
-@test latexify(f; starred = true) == "\\begin{align*}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\ \n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\ \n\\end{align*}\n"
+@test latexify(f; starred = true) == "\\begin{align*}\n\\frac{dx}{dt} =& \\frac{y}{c_{1}} - x \\\\\n\\frac{dy}{dt} =& x^{c_{2}} - y \\\\\n\\end{align*}\n"


### PR DESCRIPTION
DiffEqBiologicals reaction networks result in a lot of ugly `+ (-1 * ...)` terms. Previously, this was solved by letting SymEngine reduce the expressions. Here, I add a non-symbolic option to do the same. 

The main benefit of this is that the order of the terms in the output becomes predictable. 

Before merging:

- [x] update docs.
- [x] update tests.