### PR TITLE
Revert arrows

### DIFF
--- a/docs/src/tutorials/DiffEqBiological.md
+++ b/docs/src/tutorials/DiffEqBiological.md
@@ -72,7 +72,7 @@ latexify(rn; env=:chemical)
 \ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
 \end{align}
 
-The default output is meant to be rendered directly on the screen. This rendering is typically done by MathJax. To get the chemical arrow notation to render automatically, I have included a MathJax command (\require{mhchem}) in the output string. If you want to use the output in a real LaTeX document, you can pass the keyword argument mathjax=false and this extra command will be omitted. In such case you should also add \usepackage{mhchem} to the preamble of your latex document.
+The default output is meant to be rendered directly on the screen. This rendering is typically done by MathJax. To get the chemical arrow notation to render automatically, I have included a MathJax command (`\require{mhchem}`) in the output string. If you want to use the output in a real LaTeX document, you can pass the keyword argument `mathjax=false` and this extra command will be omitted. In such case you should also add `\usepackage{mhchem}` to the preamble of your latex document.
 
 Another keyword argument that may be of use is `expand=false` (defaults to `true`).
 This determines whether your functions should be expanded or not.
@@ -82,11 +82,13 @@ Also, `starred=true` will change the outputted latex environment from `align` to
 latexify(rn; env=:chemical, expand=false, starred=true)
 ```
 
-\begin{align\*}
+```math
+\begin{align*}
 \require{mhchem}
-\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
-\ce{ \varnothing &->[p_{y}] y}\\\\
-\ce{ x &->[d_{x}] \varnothing}\\\\
-\ce{ y &->[d_{y}] \varnothing}\\\\
-\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
-\end{align\*}
+\ce{ \varnothing &->[\mathrm{hill2}\left( y, v_{x}, k_{x} \right)] x}\\
+\ce{ \varnothing &->[p_{y}] y}\\
+\ce{ x &->[d_{x}] \varnothing}\\
+\ce{ y &->[d_{y}] \varnothing}\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
+\end{align*}
+```

--- a/docs/src/tutorials/DiffEqBiological.md
+++ b/docs/src/tutorials/DiffEqBiological.md
@@ -64,24 +64,29 @@ Use `latexify`'s `env` keyword argument to specify that you want `:chemical` (or
 latexify(rn; env=:chemical)
 ```
 \begin{align}
-\varnothing &\xrightarrow{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} x\\\\
-\varnothing &\xrightarrow{p_{y}} y\\\\
-x &\xrightarrow{d_{x}} \varnothing\\\\
-y &\xrightarrow{d_{y}} \varnothing\\\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\\\
+\require{mhchem}
+\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
+\ce{ \varnothing &->[p_{y}] y}\\\\
+\ce{ x &->[d_{x}] \varnothing}\\\\
+\ce{ y &->[d_{y}] \varnothing}\\\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
 \end{align}
 
+The default output is meant to be rendered directly on the screen. This rendering is typically done by MathJax. To get the chemical arrow notation to render automatically, I have included a MathJax command (\require{mhchem}) in the output string. If you want to use the output in a real LaTeX document, you can pass the keyword argument mathjax=false and this extra command will be omitted. In such case you should also add \usepackage{mhchem} to the preamble of your latex document.
 
-A keyword argument that may be of use is `expand=false` (defaults to `true`).
+Another keyword argument that may be of use is `expand=false` (defaults to `true`).
 This determines whether your functions should be expanded or not.
+Also, `starred=true` will change the outputted latex environment from `align` to `align*`. This results in the equations not being numbered.
 
 ```julia
-latexify(rn; env=:chemical, expand=false)
+latexify(rn; env=:chemical, expand=false, starred=true)
 ```
-\begin{align}
-\varnothing &\xrightarrow{\mathrm{hill2}\left( y, v_{x}, k_{x} \right)} x\\\\
-\varnothing &\xrightarrow{p_{y}} y\\\\
-x &\xrightarrow{d_{x}} \varnothing\\\\
-y &\xrightarrow{d_{y}} \varnothing\\\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\\\
-\end{align}
+
+\begin{align\*}
+\require{mhchem}
+\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
+\ce{ \varnothing &->[p_{y}] y}\\\\
+\ce{ x &->[d_{x}] \varnothing}\\\\
+\ce{ y &->[d_{y}] \varnothing}\\\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
+\end{align\*}

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -34,7 +34,7 @@ include("mdtable.jl")
 include("mdtext.jl")
 
 macro generate_test(expr)
-    return :(clipboard( "\n@test $($expr) == \nraw\"$($(esc(expr)))\"\n\n"))
+    return :(clipboard("\n@test $($(string(expr))) == \nraw\"$($(esc(expr)))\"\n\n"))
 end
 
 end

--- a/src/chemical_arrows.jl
+++ b/src/chemical_arrows.jl
@@ -3,7 +3,7 @@
     function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
             expand = true, md=false, mathjax=true, starred=false, kwargs...)
 
-        str = starred ? "\\begin{align\\*}\n" : "\\begin{align}\n"
+        str = starred ? "\\begin{align*}\n" : "\\begin{align}\n"
         eol = md ? "\\\\\\\\\n" : "\\\\\n"
 
         mathjax && (str *= "\\require{mhchem}\n")
@@ -50,7 +50,7 @@
             str *= join(products, " + ")
             str *= "}$eol"
         end
-        str *= starred ? "\\end{align\\*}\n" : "\\end{align}\n"
+        str *= starred ? "\\end{align*}\n" : "\\end{align}\n"
 
         latexstr = LaTeXString(str)
         COPY_TO_CLIPBOARD && clipboard(latexstr)

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -12,6 +12,7 @@ rn = @reaction_network MyRnType begin
   (r_b, r_u), x ↔ y
 end v_x k_x p_y d_x d_y r_b r_u
 
+Latexify.@generate_test latexify(rn; env=:chem)
 
 @test latexify(rn; env=:chem) ==
 raw"\begin{align}
@@ -47,12 +48,12 @@ raw"\begin{align}
 "
 
 @test md(rn; env=:chem, starred=true) ==
-raw"\begin{align\*}
+raw"\begin{align*}
 \require{mhchem}
 \ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
 \ce{ \varnothing &->[p_{y}] y}\\\\
 \ce{ x &->[d_{x}] \varnothing}\\\\
 \ce{ y &->[d_{y}] \varnothing}\\\\
 \ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
-\end{align\*}
+\end{align*}
 "

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -15,40 +15,44 @@ end v_x k_x p_y d_x d_y r_b r_u
 
 @test latexify(rn; env=:chem) ==
 raw"\begin{align}
-\varnothing &\xrightarrow{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} x\\
-\varnothing &\xrightarrow{p_{y}} y\\
-x &\xrightarrow{d_{x}} \varnothing\\
-y &\xrightarrow{d_{y}} \varnothing\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\
+\require{mhchem}
+\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\
+\ce{ \varnothing &->[p_{y}] y}\\
+\ce{ x &->[d_{x}] \varnothing}\\
+\ce{ y &->[d_{y}] \varnothing}\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
 \end{align}
 "
 
 @test latexify(rn; env=:chem, expand=false) ==
 raw"\begin{align}
-\varnothing &\xrightarrow{\mathrm{hill2}\left( y, v_{x}, k_{x} \right)} x\\
-\varnothing &\xrightarrow{p_{y}} y\\
-x &\xrightarrow{d_{x}} \varnothing\\
-y &\xrightarrow{d_{y}} \varnothing\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\
+\require{mhchem}
+\ce{ \varnothing &->[\mathrm{hill2}\left( y, v_{x}, k_{x} \right)] x}\\
+\ce{ \varnothing &->[p_{y}] y}\\
+\ce{ x &->[d_{x}] \varnothing}\\
+\ce{ y &->[d_{y}] \varnothing}\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
 \end{align}
 "
 
 @test md(rn; env=:chem) ==
 raw"\begin{align}
-\varnothing &\xrightarrow{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} x\\\\
-\varnothing &\xrightarrow{p_{y}} y\\\\
-x &\xrightarrow{d_{x}} \varnothing\\\\
-y &\xrightarrow{d_{y}} \varnothing\\\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\\\
+\require{mhchem}
+\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
+\ce{ \varnothing &->[p_{y}] y}\\\\
+\ce{ x &->[d_{x}] \varnothing}\\\\
+\ce{ y &->[d_{y}] \varnothing}\\\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
 \end{align}
 "
 
-@test md(rn; env=:chem, starred=false) ==
-raw"\begin{align}
-\varnothing &\xrightarrow{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} x\\\\
-\varnothing &\xrightarrow{p_{y}} y\\\\
-x &\xrightarrow{d_{x}} \varnothing\\\\
-y &\xrightarrow{d_{y}} \varnothing\\\\
-x &\xrightleftharpoons[r_{u}]{r_{b}} y\\\\
-\end{align}
+@test md(rn; env=:chem, starred=true) ==
+raw"\begin{align\*}
+\require{mhchem}
+\ce{ \varnothing &->[\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}] x}\\\\
+\ce{ \varnothing &->[p_{y}] y}\\\\
+\ce{ x &->[d_{x}] \varnothing}\\\\
+\ce{ y &->[d_{y}] \varnothing}\\\\
+\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
+\end{align\*}
 "

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -12,8 +12,6 @@ rn = @reaction_network MyRnType begin
   (r_b, r_u), x ↔ y
 end v_x k_x p_y d_x d_y r_b r_u
 
-Latexify.@generate_test latexify(rn; env=:chem)
-
 @test latexify(rn; env=:chem) ==
 raw"\begin{align}
 \require{mhchem}


### PR DESCRIPTION
While katex supports `\xleftrightharpoons`, it seems that MathJax does not. I'm therefore reverting back to using the `mhchem` approach. 