### PR TITLE
Update support for broadcasted operations. 

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -58,8 +58,41 @@ function latexoperation(ex::Expr, prevOp::AbstractArray)
 
     if ex.head == :.
         ex.head = :call
-        op = string(op, ".") ## Signifies broadcasting.
+        # op = string(op, ".") ## Signifies broadcasting.
     end
+
+    string(op)[1] == '.' && (op = Symbol(string(op)[2:end]))
+
+    # infix_operators = [:<, :>, Symbol("=="), :<=, :>=, :!=]
+    comparison_operators = Dict(
+        :< => "\\lt",
+        :.< => "\\lt",
+        :> => "\\gt",
+        :.> => "\\gt",
+        Symbol("==") => "=",
+        Symbol(".==") => "=",
+        :<= => "\\leq",
+        :.<= => "\\leq",
+        :>= => "\\geq",
+        :.>= => "\\geq",
+        :!= => "\\neq",
+        :.!= => "\\neq",
+        )
+
+    if op in keys(comparison_operators) && length(args) == 3
+        str = "$(args[2]) $(comparison_operators[op]) $(args[3])"
+        str = "\\left( $str \\right)"
+        return str
+    end
+
+    ### Check for chained comparison operators
+    if ex.head == :comparison && Symbol.(args[2:2:end]) ⊆ keys(comparison_operators)
+        str = join([isodd(i) ? "$var" : comparison_operators[var] for (i, var) in enumerate(Symbol.(args))], " ")
+        str = "\\left( $str \\right)"
+        return str
+    end
+
+    # op in infix_operators && return ""
 
     op == :log10 && return "\\log_{10}\\left( $(args[2]) \\right)"
     op == :log2 && return "\\log_{2}\\left( $(args[2]) \\right)"

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -47,7 +47,7 @@ array_test = [ex, str]
 @test latexraw("x[2, 3]") == raw"\mathrm{x}\left[2, 3\right]"
 
 ### Test broadcasting
-@test latexraw(:(sum.((a, b)))) == raw"\mathrm{sum.}\left( a, b \right)"
+@test latexraw(:(sum.((a, b)))) == raw"\mathrm{sum}\left( a, b \right)"
 
 
 f = @ode_def TestRaw begin
@@ -70,3 +70,7 @@ end c_1 c_2
 @test latexraw("1 - 2 - (- 3 -(2 - 8) + 4)") == raw"1 - 2 - \left(  - 3 - \left( 2 - 8 \right) + 4 \right)"
 
 @test_throws ErrorException latexify("x/y"; env=:raw, bad_kwarg="should error")
+
+
+@test latexraw(:(3 * (a .< b .<= c < d <= e > f <= g .<= h .< i == j .== k != l .!= m))) ==
+raw"3 \cdot \left( a \lt b \leq c \lt d \leq e \gt f \leq g \leq h \lt i = j = k \neq l \neq m \right)"


### PR DESCRIPTION
See #33 

This strips all dots and basically ignores broadcasting.

I cringe a bit as a mathematician since this allows for misrepresentations without raising errors. However, I agree that this is more useful than an error, and I will defer the correctness of the mathematics to the user. 

This also adds infix support for (chained) comparison operations:
```julia
latexify(:(a .<= b .< c .== a))
```
$\left( a \leq b \lt c = a \right)$
