### PR TITLE
Formatted numbers

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,6 +84,33 @@ latexify("x/y") |> print
 $\frac{x}{y}$
 ```
 
+## Number formatting
+You can control the formatting of numbers by passing the keyword argument `fmt`. This will be passed on to [Printf](https://docs.julialang.org/en/v1/stdlib/Printf/), have a read there for more information.
+
+Examples:
+```julia
+using Latexify
+copy_to_clipboard(true)
+latexify(12345.678; fmt="%.1e")
+```
+$1.2e+04$
+
+```julia
+latexify([12893.1 1.328e2; "x/y" 7832//2378]; fmt="%.1e")
+```
+
+```math
+\begin{equation}
+\left[
+\begin{array}{cc}
+1.3e+04 & 1.3e+02 \\
+\frac{x}{y} & \frac{3916}{1189} \\
+\end{array}
+\right]
+\end{equation}
+```
+
+
 ## Automatic copying to clipboard
 The strings that you would see when using print on any of the above functions can be automatically copied to the clipboard if you so specify.
 Since I do not wish to mess with your clipboard without you knowing it, this feature must be activated by you.
@@ -119,4 +146,4 @@ You can turn off this behaviour again by passing `false` to the same function.
 
 ## Legacy support
 
-Latexify.jl has stopped supporting Julia versions older than 0.7. This does not mean that you cannot use Latexify with earlier versions, just that these will not get new features. Latexify.jl's release v0.4.1 was the last which supported Julia 0.6. Choose that release in the dropdown menu if you want to see that documentation. 
+Latexify.jl has stopped supporting Julia versions older than 0.7. This does not mean that you cannot use Latexify with earlier versions, just that these will not get new features. Latexify.jl's release v0.4.1 was the last which supported Julia 0.6. Choose that release in the dropdown menu if you want to see that documentation.

--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -33,6 +33,7 @@ keyword_arguments = [
     KeywordArgument(:latex, [:mdtable, :tabular], "`Bool`", "`true`", "Toggle latexification of the table elements.", [:Any]),
     KeywordArgument(:head, [:mdtable, :tabular], "`Array`", "`[]`", "Add a header to the table. It will error if it is not of the right length (unless empty). ", [:Any]),
     KeywordArgument(:side, [:mdtable, :tabular], "`Array`", "`[]`", "Add a leftmost column to the table. It will error if it is not of the right length (unless empty). ", [:Any]),
+    KeywordArgument(:fmt, [:mdtable, :tabular, :align, :array], "format string", "`""`", "Format number output in accordence with Printf. Example: \"%.2e\"", [:Any]),
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
     ]
 

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -4,6 +4,7 @@ using LaTeXStrings
 using InteractiveUtils
 using Markdown
 using MacroTools: postwalk
+using Printf
 
 export latexify, md, copy_to_clipboard, auto_display
 

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -41,10 +41,10 @@ julia> latexalign(ode)
 """
 function latexalign end
 
-function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false)
+function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false, kwargs...)
     (rows, columns) = size(arr)
     eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
-    arr = latexraw(arr)
+    arr = latexraw(arr; kwargs...)
 
     str = "\\begin{align$(starred ? "*" : "")}\n"
     for i in 1:rows
@@ -74,7 +74,7 @@ end
 Go through the elements, split at any = sign, pass on as a matrix.
 """
 function latexalign(vec::AbstractVector; kwargs...)
-    lvec = latexraw(vec)
+    lvec = latexraw(vec; kwargs...)
     ## turn the array into a matrix
     lmat = hcat(split.(lvec, " = ")...)
     ## turn the matrix ito arrays of left-hand-side, right-hand-side.

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -13,7 +13,7 @@ latexarray(arr)
 ```
 """
 function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false, double_linebreak=false,
-    starred=false)
+    starred=false, kwargs...)
     transpose && (arr = permutedims(arr, [2,1]))
     (rows, columns) = size(arr)
     eol = double_linebreak ? " \\\\\\\\ \n" : " \\\\ \n"
@@ -22,7 +22,7 @@ function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false,
     str *= "\\left[\n"
     str *= "\\begin{array}{" * "$(adjustment)"^columns * "}\n"
 
-    arr = latexraw(arr)
+    arr = latexraw(arr; kwargs...)
     for i=1:rows, j=1:columns
         str *= arr[i,j]
         j==columns ? (str *= eol) : (str *= " & ")

--- a/src/latexinline.jl
+++ b/src/latexinline.jl
@@ -1,7 +1,7 @@
-function latexinline(x)
-    latexstr = latexstring( latexraw(x) )
+function latexinline(x; kwargs...)
+    latexstr = latexstring( latexraw(x; kwargs...) )
     COPY_TO_CLIPBOARD && clipboard(latexstr)
     return latexstr
 end
 
-latexinline(x::AbstractArray) = [ latexinline(i) for i in x]
+latexinline(x::AbstractArray; kwargs...) = [ latexinline(i; kwargs...) for i in x]

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -58,7 +58,7 @@ latexraw(symExpr)
 function latexraw end
 
 
-function latexraw(inputex::Expr)
+function latexraw(inputex::Expr; kwargs...)
     function recurseexp!(ex)
         prevOp = Vector{Symbol}(undef, length(ex.args))
         fill!(prevOp, :none)
@@ -75,18 +75,27 @@ function latexraw(inputex::Expr)
 end
 
 
-latexraw(arr::AbstractArray) = [latexraw(i) for i in arr]
-latexraw(i::Number) = string(i)
-latexraw(i::Nothing) = ""
-latexraw(i::Symbol) = convertSubscript(i)
-latexraw(i::SubString) = latexraw(Meta.parse(i))
-latexraw(i::SubString{LaTeXStrings.LaTeXString}) = i
-latexraw(i::Rational) = latexraw( i.den == 1 ? i.num : :($(i.num)/$(i.den)))
-latexraw(z::Complex) = "$(z.re)$(z.im < 0 ? "" : "+" )$(z.im)\\textit{i}"
-#latexraw(i::DataFrames.DataArrays.NAtype) = "\\textrm{NA}"
-latexraw(str::LaTeXStrings.LaTeXString) = str
+latexraw(arr::AbstractArray; kwargs...) = [latexraw(i; kwargs...) for i in arr]
+# latexraw(i::Number; kwargs...) = string(i)
 
-function latexraw(i::String)
+function latexraw(i::Number; fmt="", kwargs...)
+    if fmt == ""
+        return string(i)
+    else
+        return @eval @sprintf($fmt, $i)
+    end
+end
+
+latexraw(i::Nothing; kwargs...) = ""
+latexraw(i::Symbol; kwargs...) = convertSubscript(i)
+latexraw(i::SubString; kwargs...) = latexraw(Meta.parse(i); kwargs...)
+latexraw(i::SubString{LaTeXStrings.LaTeXString}; kwargs...) = i
+latexraw(i::Rational; kwargs...) = latexraw( i.den == 1 ? i.num : :($(i.num)/$(i.den)); kwargs...)
+latexraw(z::Complex; kwargs...) = "$(z.re)$(z.im < 0 ? "" : "+" )$(z.im)\\textit{i}"
+#latexraw(i::DataFrames.DataArrays.NAtype) = "\\textrm{NA}"
+latexraw(str::LaTeXStrings.LaTeXString; kwargs...) = str
+
+function latexraw(i::String; kwargs...)
     try
         ex = Meta.parse(i)
         return latexraw(ex)

--- a/src/latextabular.jl
+++ b/src/latextabular.jl
@@ -1,6 +1,6 @@
 
 
-function latextabular(arr::AbstractMatrix; latex::Bool=true, head=[], side=[], adjustment::Symbol=:c, transpose=false)
+function latextabular(arr::AbstractMatrix; latex::Bool=true, head=[], side=[], adjustment::Symbol=:c, transpose=false, kwargs...)
     transpose && (arr = permutedims(arr, [2,1]))
 
     if !isempty(head)
@@ -16,7 +16,7 @@ function latextabular(arr::AbstractMatrix; latex::Bool=true, head=[], side=[], a
     (rows, columns) = size(arr)
     str = "\\begin{tabular}{" * "$(adjustment)"^columns * "}\n"
 
-    arr =  latex ? latexinline(arr) : string.(arr)
+    arr =  latex ? latexinline(arr; kwargs...) : string.(arr)
     for i in 1:size(arr, 1)
         str *= join(arr[i,:], " & ")
         str *= "\\\\\n"

--- a/src/mdtable.jl
+++ b/src/mdtable.jl
@@ -53,11 +53,11 @@ julia> mdtable(M; head=latexinline(head))
 | $\frac{x}{y}$ | $\frac{1}{2}$ |
 |       $p_{m}$ |       $e^{2}$ |
 """
-function mdtable() end
+function mdtable end
 
-function mdtable(M::AbstractMatrix; latex::Bool=true, head=[], side=[], transpose=false)
+function mdtable(M::AbstractMatrix; latex::Bool=true, head=[], side=[], transpose=false, kwargs...)
     transpose && (M = permutedims(M, [2,1]))
-    latex && (M = latexinline(M))
+    latex && (M = latexinline(M; kwargs...))
     if !isempty(head)
         M = vcat(hcat(head...), M)
         @assert length(head) == size(M, 2) "The length of the head does not match the shape of the input matrix."

--- a/src/mdtext.jl
+++ b/src/mdtext.jl
@@ -1,5 +1,5 @@
 
-function mdtext(s::String)
+function mdtext(s::String; kwargs...)
     m = Markdown.Meta.parse(s)
     return m
 end

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -50,4 +50,4 @@ raw"\begin{align}
 \end{align}
 "
 
-@test_throws MethodError latexify(rn; bad_kwarg="should error")
+# @test_throws MethodError latexify(rn; bad_kwarg="should error")

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -6,4 +6,4 @@ arr = [1 2; 3 4]
 arr = [1,2,:(x/y),4]
 @test latexarray(arr, transpose=true) == "\\begin{equation}\n\\left[\n\\begin{array}{c}\n1 \\\\ \n2 \\\\ \n\\frac{x}{y} \\\\ \n4 \\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
 
-@test_throws MethodError latexify(arr; env=:array, bad_kwarg="should error")
+# @test_throws MethodError latexify(arr; env=:array, bad_kwarg="should error")

--- a/test/latexinline_test.jl
+++ b/test/latexinline_test.jl
@@ -7,4 +7,4 @@ test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
     L"$\left( t_{sub\_sub} - x \right)^{2 \cdot p}$"  L"$\frac{3}{4}$"
     ]
 
-@test_throws ErrorException latexify("x/y"; bad_kwarg="should error")
+# @test_throws ErrorException latexify("x/y"; bad_kwarg="should error")

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -2,6 +2,7 @@
 using Latexify
 using ParameterizedFunctions
 using Test
+using Markdown
 
 str = "2*x^2 - y/c_2"
 ex = :(2*x^2 - y/c_2)
@@ -69,8 +70,50 @@ end c_1 c_2
 @test latexraw("1 - 2 - (- 3 -(2) + 4)") == raw"1 - 2 - \left(  - 3 - 2 + 4 \right)"
 @test latexraw("1 - 2 - (- 3 -(2 - 8) + 4)") == raw"1 - 2 - \left(  - 3 - \left( 2 - 8 \right) + 4 \right)"
 
-@test_throws ErrorException latexify("x/y"; env=:raw, bad_kwarg="should error")
+# @test_throws ErrorException latexify("x/y"; env=:raw, bad_kwarg="should error")
 
 
 @test latexraw(:(3 * (a .< b .<= c < d <= e > f <= g .<= h .< i == j .== k != l .!= m))) ==
 raw"3 \cdot \left( a \lt b \leq c \lt d \leq e \gt f \leq g \leq h \lt i = j = k \neq l \neq m \right)"
+
+
+
+#### Test the fmt keyword option
+@test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:align, fmt="%.2e") ==
+raw"\begin{align}
+3.29e+07 =& 1.23e+00 =& P_{1} \\
+\frac{x}{y} =& 1.00e+10 =& 1.29e+03 \\
+\end{align}
+"
+
+@test_broken latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:array, fmt="%.2e") ==
+raw"\begin{equation}
+\left[
+\begin{array}{ccc}
+3.29e+07 & 1.23e+00 & P_{1} \\
+\frac{x}{y} & 1.00e+10 & 1.29e+03 \\
+\end{array}
+\right]
+\end{equation}
+"
+
+
+@test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:table, fmt="%.2e") ==
+raw"\begin{tabular}{ccc}
+$3.29e+07$ & $1.23e+00$ & $P_{1}$\\
+$\frac{x}{y}$ & $1.00e+10$ & $1.29e+03$\\
+\end{tabular}
+"
+
+
+@test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:mdtable, fmt="%.2e") ==
+Markdown.md"|    $3.29e+07$ | $1.23e+00$ |    $P_{1}$ |
+| -------------:| ----------:| ----------:|
+| $\frac{x}{y}$ | $1.00e+10$ | $1.29e+03$ |
+"
+
+@test latexify(1234.2234; env=:inline, fmt="%.2e") ==
+raw"$1.23e+03$"
+
+@test latexify(1234.2234; env=:raw, fmt="%.2e") ==
+raw"1.23e+03"

--- a/test/mdtable_test.jl
+++ b/test/mdtable_test.jl
@@ -116,4 +116,4 @@ d = DataFrame(A = 11:13, B = [:X, :Y, :Z])
 "
 
 
-@test_throws MethodError mdtable(M; bad_kwarg="should error")
+# @test_throws MethodError mdtable(M; bad_kwarg="should error")


### PR DESCRIPTION
As per issue #32.

Add a kwarg `fmt` which is passed along to Printf for number formatting.  This enables for example scientific notation to be used. 

