### PR TITLE
Index consistency fix

### DIFF
--- a/src/plugins/DiffEqBiological.jl
+++ b/src/plugins/DiffEqBiological.jl
@@ -83,8 +83,8 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
             expand && (rate_backwards = DiffEqBiological.recursive_clean!(rate_backwards))
             expand && (rate_backwards = DiffEqBiological.recursive_clean!(rate_backwards))
             str *= " &<=>"
-            str *= "[{" * latexraw(rate) * "}]"
-            str *= "[{" * latexraw(rate_backwards) * "}] "
+            str *= "[" * latexraw(rate) * "]"
+            str *= "[" * latexraw(rate_backwards) * "] "
             backwards_reaction = true
         else
             ### Uni-directional arrows

--- a/src/plugins/DiffEqBiological.jl
+++ b/src/plugins/DiffEqBiological.jl
@@ -98,6 +98,8 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
         str *= join(products, " + ")
         str *= "}$eol"
     end
+    str = str[1:end-length(eol)] * "\n"
+    
     str *= starred ? "\\end{align*}\n" : "\\end{align}\n"
 
     latexstr = LaTeXString(str)

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -18,7 +18,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[r_{b}][r_{u}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}
 \end{align}
 "
 
@@ -29,7 +29,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[r_{b}][r_{u}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}
 \end{align}
 "
 
@@ -40,7 +40,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[r_{b}][r_{u}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}
 \end{align}
 "
 
@@ -51,7 +51,7 @@ raw"\begin{align*}
 \ce{ \varnothing &->[p_{y}] y}\\\\
 \ce{ x &->[d_{x}] \varnothing}\\\\
 \ce{ y &->[d_{y}] \varnothing}\\\\
-\ce{ x &<=>[r_{b}][r_{u}] y}\\\\
+\ce{ x &<=>[r_{b}][r_{u}] y}
 \end{align*}
 "
 
@@ -72,7 +72,7 @@ raw"\begin{align}
 \ce{ R &->[d_{R}] \varnothing}\\
 \ce{ \varnothing &->[p_{F}] F}\\
 \ce{ \varnothing &->[Ff] R}\\
-\ce{ F &<=>[r_{b} \cdot i][r_{u}] Ff}\\
+\ce{ F &<=>[r_{b} \cdot i][r_{u}] Ff}
 \end{align}
 "
 

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -18,7 +18,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}\\
 \end{align}
 "
 
@@ -29,7 +29,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}\\
 \end{align}
 "
 
@@ -40,7 +40,7 @@ raw"\begin{align}
 \ce{ \varnothing &->[p_{y}] y}\\
 \ce{ x &->[d_{x}] \varnothing}\\
 \ce{ y &->[d_{y}] \varnothing}\\
-\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\
+\ce{ x &<=>[r_{b}][r_{u}] y}\\
 \end{align}
 "
 
@@ -51,7 +51,7 @@ raw"\begin{align*}
 \ce{ \varnothing &->[p_{y}] y}\\\\
 \ce{ x &->[d_{x}] \varnothing}\\\\
 \ce{ y &->[d_{y}] \varnothing}\\\\
-\ce{ x &<=>[{r_{b}}][{r_{u}}] y}\\\\
+\ce{ x &<=>[r_{b}][r_{u}] y}\\\\
 \end{align*}
 "
 
@@ -72,7 +72,7 @@ raw"\begin{align}
 \ce{ R &->[d_{R}] \varnothing}\\
 \ce{ \varnothing &->[p_{F}] F}\\
 \ce{ \varnothing &->[Ff] R}\\
-\ce{ F &<=>[{r_{b} \cdot i}][{r_{u}}] Ff}\\
+\ce{ F &<=>[r_{b} \cdot i][r_{u}] Ff}\\
 \end{align}
 "
 


### PR DESCRIPTION
Fix an index inconsistency for chemical arrows. Closes #41.

Also, remove an excessive `\\` which causes enumeration of an empty arrow at the end of the expression. 