### PR TITLE
Add unicode-to-LaTeX conversion.

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -5,6 +5,7 @@ using InteractiveUtils
 using Markdown
 using MacroTools: postwalk
 using Printf
+using REPL
 
 export latexify, md, copy_to_clipboard, auto_display
 
@@ -20,6 +21,14 @@ AUTO_DISPLAY = false
 function auto_display(x::Bool)
     global AUTO_DISPLAY = x
 end
+
+const unicodedict = Dict(val[1] => key for (key, val) in REPL.REPLCompletions.latex_symbols)
+
+function unicode2latex(str::String)
+    isascii(str) && return str
+    join(map(key->haskey(unicodedict, key) ? unicodedict[key] : key, [s for s in str]))
+end
+
 
 include("latexraw.jl")
 include("latexoperation.jl")

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -26,7 +26,12 @@ const unicodedict = Dict(val[1] => key for (key, val) in REPL.REPLCompletions.la
 
 function unicode2latex(str::String)
     isascii(str) && return str
-    join(map(key->haskey(unicodedict, key) ? unicodedict[key] : key, [s for s in str]))
+    join(
+        map(
+            key-> isascii(key) || !haskey(unicodedict, key) ? key : unicodedict[key],
+            [s for s in str]
+            )
+        )
 end
 
 

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -71,7 +71,9 @@ function latexraw(inputex::Expr; kwargs...)
         return latexoperation(ex, prevOp)
     end
     ex = deepcopy(inputex)
-    LaTeXString(recurseexp!(ex))
+    str = recurseexp!(ex)
+    str = unicode2latex(str)
+    LaTeXString(str)
 end
 
 
@@ -87,7 +89,7 @@ function latexraw(i::Number; fmt="", kwargs...)
 end
 
 latexraw(i::Nothing; kwargs...) = ""
-latexraw(i::Symbol; kwargs...) = convertSubscript(i)
+latexraw(i::Symbol; kwargs...) = unicode2latex(convertSubscript(i))
 latexraw(i::SubString; kwargs...) = latexraw(Meta.parse(i); kwargs...)
 latexraw(i::SubString{LaTeXStrings.LaTeXString}; kwargs...) = i
 latexraw(i::Rational; kwargs...) = latexraw( i.den == 1 ? i.num : :($(i.num)/$(i.den)); kwargs...)

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -46,7 +46,8 @@ array_test = [ex, str]
 @test latexraw(Missing()) == "\\textrm{NA}"
 @test latexraw("x[2]") == raw"\mathrm{x}\left[2\right]"
 @test latexraw("x[2, 3]") == raw"\mathrm{x}\left[2, 3\right]"
-
+@test latexraw("α") == raw"\alpha"
+@test latexraw("α + 1") == raw"\alpha + 1"
 ### Test broadcasting
 @test latexraw(:(sum.((a, b)))) == raw"\mathrm{sum}\left( a, b \right)"
 


### PR DESCRIPTION
Convert for example `"α"` to `"\alpha"`. Closes #35. 

Thanks to @isaacsas for pointing out where to find a unicode to latex correspondence dictionary. 