### PR TITLE
Add escape_underscore kwarg for Markdown.

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -34,6 +34,7 @@ keyword_arguments = [
     KeywordArgument(:head, [:mdtable, :tabular], "`Array`", "`[]`", "Add a header to the table. It will error if it is not of the right length (unless empty). ", [:Any]),
     KeywordArgument(:side, [:mdtable, :tabular], "`Array`", "`[]`", "Add a leftmost column to the table. It will error if it is not of the right length (unless empty). ", [:Any]),
     KeywordArgument(:fmt, [:mdtable, :tabular, :align, :array], "format string", "`\"\"`", "Format number output in accordence with Printf. Example: \"%.2e\"", [:Any]),
+    KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
     ]
 

--- a/src/mdtable.jl
+++ b/src/mdtable.jl
@@ -55,7 +55,7 @@ julia> mdtable(M; head=latexinline(head))
 """
 function mdtable end
 
-function mdtable(M::AbstractMatrix; latex::Bool=true, head=[], side=[], transpose=false, kwargs...)
+function mdtable(M::AbstractMatrix; latex::Bool=true, escape_underscores=false, head=[], side=[], transpose=false, kwargs...)
     transpose && (M = permutedims(M, [2,1]))
     latex && (M = latexinline(M; kwargs...))
     if !isempty(head)
@@ -73,6 +73,8 @@ function mdtable(M::AbstractMatrix; latex::Bool=true, head=[], side=[], transpos
     for i in 2:size(M,1)
         t *= "| " * join(M[i,:], " | ") * " |\n"
     end
+
+    escape_underscores && (t = replace(t, "_"=>"\\_"))
     t = Markdown.parse(t)
     COPY_TO_CLIPBOARD && clipboard(t)
     return t

--- a/src/mdtext.jl
+++ b/src/mdtext.jl
@@ -1,5 +1,6 @@
 
-function mdtext(s::String; kwargs...)
-    m = Markdown.Meta.parse(s)
+function mdtext(s::String; escape_underscores = false, kwargs...)
+    escape_underscores && (s = replace(s, "_"=>"\\_"))
+    m = Markdown.parse(s)
     return m
 end

--- a/test/mdtable_test.jl
+++ b/test/mdtable_test.jl
@@ -95,6 +95,16 @@ side = ["row$i" for i in 1:size(M, 1)]
 | col5 |            $symb$ |            $symb$ |
 "
 
+
+m = ["one_two_tree"; "four_five_six"; "seven_eight"]
+@test latexify(m; env=:mdtable, latex=false, escape_underscores=true) == Markdown.md"
+|  one\_two\_tree |
+| -------------:|
+| four\_five\_six |
+|   seven_eight |
+"
+
+
 using DataFrames
 d = DataFrame(A = 11:13, B = [:X, :Y, :Z])
 


### PR DESCRIPTION
Underscores can denote italics in markdown. Sometimes this is not what you want. This adds a kwarg to escape the underscores.