### PR TITLE
add usecdot kwarg

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -36,6 +36,7 @@ keyword_arguments = [
     KeywordArgument(:fmt, [:mdtable, :tabular, :align, :array, :raw, :inline], "format string", "`\"\"`", "Format number output in accordence with Printf. Example: \"%.2e\"", [:Any]),
     KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
     KeywordArgument(:convert_unicode, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Convert unicode characters to latex commands, for example `α` to `\\alpha`", [:Any]),
+    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\cdot` or just a space to represent multiplication.", [:Any]),
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
     ]
 

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -7,7 +7,7 @@ This uses the information about the previous operations to decide if
 a parenthesis is needed.
 
 """
-function latexoperation(ex::Expr, prevOp::AbstractArray; usecdot=true, kwargs...)
+function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     op = ex.args[1]
     convertSubscript!(ex)
     args = ex.args
@@ -20,7 +20,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; usecdot=true, kwargs...
             arg = args[i]
             prevOp[i] in [:+, :-]  && (arg = "\\left( $arg \\right)")
             str = string(str, arg)
-            i != length(args) && (str *= usecdot ? " \\cdot " : " ")
+            i != length(args) && (str *= cdot ? " \\cdot " : " ")
         end
         return str
 

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -7,7 +7,7 @@ This uses the information about the previous operations to decide if
 a parenthesis is needed.
 
 """
-function latexoperation(ex::Expr, prevOp::AbstractArray)
+function latexoperation(ex::Expr, prevOp::AbstractArray; usecdot=true, kwargs...)
     op = ex.args[1]
     convertSubscript!(ex)
     args = ex.args
@@ -20,7 +20,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray)
             arg = args[i]
             prevOp[i] in [:+, :-]  && (arg = "\\left( $arg \\right)")
             str = string(str, arg)
-            i != length(args) && (str *= " \\cdot ")
+            i != length(args) && (str *= usecdot ? " \\cdot " : " ")
         end
         return str
 
@@ -160,7 +160,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray)
     return ""
 end
 
-latexoperation(sym::Symbol, prevOp::AbstractArray) = "$sym"
+latexoperation(sym::Symbol, prevOp::AbstractArray; kwargs...) = "$sym"
 
 
 function convertSubscript!(ex::Expr)

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -68,7 +68,7 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                 ex.args[i] = recurseexp!(ex.args[i])
             end
         end
-        return latexoperation(ex, prevOp)
+        return latexoperation(ex, prevOp; kwargs...)
     end
     ex = deepcopy(inputex)
     str = recurseexp!(ex)

--- a/src/plugins/DiffEqBiological.jl
+++ b/src/plugins/DiffEqBiological.jl
@@ -49,8 +49,7 @@ end
 
 
 function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
-    expand = true, double_linebreak=false, mathjax=true, starred=false)
-
+    expand = true, double_linebreak=false, mathjax=true, starred=false, kwargs...)
     str = starred ? "\\begin{align*}\n" : "\\begin{align}\n"
     eol = double_linebreak ? "\\\\\\\\\n" : "\\\\\n"
 
@@ -71,7 +70,7 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
         expand && (rate = DiffEqBiological.recursive_clean!(rate))
 
         ### Generate formatted string of substrates
-        substrates = [latexraw("$(substrate.stoichiometry== 1 ? "" : "$(substrate.stoichiometry) * ") $(substrate.reactant)") for substrate in r.substrates ]
+        substrates = [latexraw("$(substrate.stoichiometry== 1 ? "" : "$(substrate.stoichiometry) * ") $(substrate.reactant)"; kwargs...) for substrate in r.substrates ]
         isempty(substrates) && (substrates = ["\\varnothing"])
 
         str *= join(substrates, " + ")
@@ -83,17 +82,17 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
             expand && (rate_backwards = DiffEqBiological.recursive_clean!(rate_backwards))
             expand && (rate_backwards = DiffEqBiological.recursive_clean!(rate_backwards))
             str *= " &<=>"
-            str *= "[" * latexraw(rate) * "]"
-            str *= "[" * latexraw(rate_backwards) * "] "
+            str *= "[" * latexraw(rate; kwargs...) * "]"
+            str *= "[" * latexraw(rate_backwards; kwargs...) * "] "
             backwards_reaction = true
         else
             ### Uni-directional arrows
             str *= " &->"
-            str *= "[" * latexraw(rate) * "] "
+            str *= "[" * latexraw(rate; kwargs...) * "] "
         end
 
         ### Generate formatted string of products
-        products = [latexraw("$(product.stoichiometry== 1 ? "" : "$(product.stoichiometry) * ") $(product.reactant)") for product in r.products ]
+        products = [latexraw("$(product.stoichiometry== 1 ? "" : "$(product.stoichiometry) * ") $(product.reactant)"; kwargs...) for product in r.products ]
         isempty(products) && (products = ["\\varnothing"])
         str *= join(products, " + ")
         str *= "}$eol"

--- a/src/plugins/ParameterizedFunctions.jl
+++ b/src/plugins/ParameterizedFunctions.jl
@@ -16,16 +16,16 @@ end
 #         Overload environment functions      #
 ###############################################
 
-function latexraw(ode::DiffEqBase.AbstractParameterizedFunction)
+function latexraw(ode::DiffEqBase.AbstractParameterizedFunction; kwargs...)
     lhs = ["\\frac{d$x}{dt} = " for x in ode.syms]
-    rhs = latexraw(ode.funcs)
+    rhs = latexraw(ode.funcs; kwargs...)
     return lhs .* rhs
 end
 
 
-function latexinline(ode::DiffEqBase.AbstractParameterizedFunction)
+function latexinline(ode::DiffEqBase.AbstractParameterizedFunction; kwargs...)
     lhs = ["\\frac{d$x}{dt} = " for x in ode.syms]
-    rhs = latexraw(ode.funcs)
+    rhs = latexraw(ode.funcs; kwargs...)
     return latexstring.( lhs .* rhs )
 end
 

--- a/src/plugins/SymEngine.jl
+++ b/src/plugins/SymEngine.jl
@@ -7,10 +7,10 @@
 #         Overload environment functions      #
 ###############################################
 
-function latexraw(x::SymEngine.Basic)
+function latexraw(x::SymEngine.Basic; kwargs...)
     str = string(x)
     ex = Meta.parse(str)
-    latexraw(ex)
+    latexraw(ex; kwargs...)
 end
 
 ###############################################

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -69,6 +69,8 @@ raw"\begin{align}
 "
 
 # reactions
+if VERSION >= v"1.0"
+
 rn = @reaction_network begin
     hillr(D₂,α,K,n), ∅ --> m₁
     hillr(D₁,α,K,n), ∅ --> m₂
@@ -165,6 +167,7 @@ $0$ & $0$ & $0$ & $k_+ \cdot P_2$ & $0$ & $ - k_-$ & $0$\\
 $0$ & $0$ & $k_+ \cdot P_2$ & $k_+ \cdot P_1$ & $0$ & $0$ & $ - k_-$\\
 \end{tabular}
 "
+end
 
 # mdtable
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -49,7 +49,7 @@ x \cdot y & x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdo
 "
 
 # align
-f = @ode_def TestAlignFeedback begin
+f = @ode_def TestAlignFeedback2 begin
     dx = y*c_1 - x
     dy = x^c_2 - y
 end c_1 c_2

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -69,6 +69,8 @@ raw"\begin{align}
 "
 
 # reactions
+if VERSION >= v"1.0"
+
 rn = @reaction_network begin
     hillr(D₂,α,K,n), ∅ --> m₁
     hillr(D₁,α,K,n), ∅ --> m₂
@@ -144,8 +146,8 @@ raw"\begin{align}
 # tabular
 @test latexify(rn.symjac; env=:tabular, cdot=false) == 
 raw"\begin{tabular}{ccccccc}
-$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
-$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_2^{-1 + n}}{\left( D_2^{n} + K^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_1^{-1 + n}}{\left( D_1^{n} + K^{n} \right)^{2}}$ & $0$ & $0$\\
 $\beta$ & $0$ & $ - \mu - 2 k_+ P_1 - k_+ P_2$ & $ - k_+ P_1$ & $2 k_-$ & $0$ & $k_{-}$\\
 $0$ & $\beta$ & $ - k_+ P_2$ & $ - \mu - k_+ P_1 - 2 k_+ P_2$ & $0$ & $2 k_-$ & $k_{-}$\\
 $0$ & $0$ & $k_+ P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
@@ -156,8 +158,8 @@ $0$ & $0$ & $k_+ P_2$ & $k_+ P_1$ & $0$ & $0$ & $ - k_-$\\
 
 @test latexify(rn.symjac; env=:tabular, cdot=true) == 
 raw"\begin{tabular}{ccccccc}
-$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
-$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_2^{-1 + n}}{\left( D_2^{n} + K^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_1^{-1 + n}}{\left( D_1^{n} + K^{n} \right)^{2}}$ & $0$ & $0$\\
 $\beta$ & $0$ & $ - \mu - 2 \cdot k_+ \cdot P_1 - k_+ \cdot P_2$ & $ - k_+ \cdot P_1$ & $2 \cdot k_-$ & $0$ & $k_{-}$\\
 $0$ & $\beta$ & $ - k_+ \cdot P_2$ & $ - \mu - k_+ \cdot P_1 - 2 \cdot k_+ \cdot P_2$ & $0$ & $2 \cdot k_-$ & $k_{-}$\\
 $0$ & $0$ & $k_+ \cdot P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
@@ -165,6 +167,8 @@ $0$ & $0$ & $0$ & $k_+ \cdot P_2$ & $0$ & $ - k_-$ & $0$\\
 $0$ & $0$ & $k_+ \cdot P_2$ & $k_+ \cdot P_1$ & $0$ & $0$ & $ - k_-$\\
 \end{tabular}
 "
+
+end
 
 # mdtable
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -1,0 +1,192 @@
+using Latexify
+using DiffEqBiological
+using ParameterizedFunctions
+using Markdown
+using Test
+
+
+#inline
+@test latexify(:(x * y); env=:inline, cdot=false) == raw"$x y$"
+
+@test latexify(:(x * y); env=:inline, cdot=true) == raw"$x \cdot y$"
+
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=false) == 
+raw"$x \left( y + z \right) y \left( z + a \right) \left( z + b \right)$"
+
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=true) == 
+raw"$x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)$"
+
+# raw
+@test latexify(:(x * y); env=:raw, cdot=false) == raw"x y"
+
+@test latexify(:(x * y); env=:raw, cdot=true) == raw"x \cdot y"
+
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=false) == 
+raw"x \left( y + z \right) y \left( z + a \right) \left( z + b \right)"
+
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=true) == 
+raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)"
+
+# array
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, cdot=false) ==
+raw"\begin{equation}
+\left[
+\begin{array}{cc}
+x y & x \left( y + z \right) y \left( z + a \right) \left( z + b \right) \\
+\end{array}
+\right]
+\end{equation}
+"
+
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, cdot=true) == 
+raw"\begin{equation}
+\left[
+\begin{array}{cc}
+x \cdot y & x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right) \\
+\end{array}
+\right]
+\end{equation}
+"
+
+# align
+f = @ode_def TestAlignFeedback begin
+    dx = y*c_1 - x
+    dy = x^c_2 - y
+end c_1 c_2
+
+@test latexify(f; env=:align, cdot=false) == 
+raw"\begin{align}
+\frac{dx}{dt} =& y c_{1} - x \\
+\frac{dy}{dt} =& x^{c_{2}} - y \\
+\end{align}
+"
+
+@test latexify(f; env=:align, cdot=true) == 
+raw"\begin{align}
+\frac{dx}{dt} =& y \cdot c_{1} - x \\
+\frac{dy}{dt} =& x^{c_{2}} - y \\
+\end{align}
+"
+
+# reactions
+rn = @reaction_network begin
+    hillr(D₂,α,K,n), ∅ --> m₁
+    hillr(D₁,α,K,n), ∅ --> m₂
+    (δ,γ), m₁ ↔ ∅
+    (δ,γ), m₂ ↔ ∅
+    β, m₁ --> m₁ + P₁
+    β, m₂ --> m₂ + P₂
+    μ, P₁ --> ∅
+    μ, P₂ --> ∅
+    (k₊,k₋), 2P₁ ↔ D₁ 
+    (k₊,k₋), 2P₂ ↔ D₂
+    (k₊,k₋), P₁+P₂ ↔ T
+end α K n δ γ β μ k₊ k₋;
+
+@test latexify(rn; cdot=false) == 
+raw"\begin{align}
+\frac{dm_1}{dt} =& \frac{\alpha K^{n}}{K^{n} + D_2^{n}} - \delta m_1 + \gamma \\
+\frac{dm_2}{dt} =& \frac{\alpha K^{n}}{K^{n} + D_1^{n}} - \delta m_2 + \gamma \\
+\frac{dP_1}{dt} =& \beta m_1 - \mu P_1 -2 k_+ \frac{P_1^{2}}{2} + 2 k_- D_1 - k_+ P_1 P_2 + k_- T \\
+\frac{dP_2}{dt} =& \beta m_2 - \mu P_2 -2 k_+ \frac{P_2^{2}}{2} + 2 k_- D_2 - k_+ P_1 P_2 + k_- T \\
+\frac{dD_1}{dt} =& k_+ \frac{P_1^{2}}{2} - k_- D_1 \\
+\frac{dD_2}{dt} =& k_+ \frac{P_2^{2}}{2} - k_- D_2 \\
+\frac{dT}{dt} =& k_+ P_1 P_2 - k_- T \\
+\end{align}
+"
+
+@test latexify(rn; cdot=true) == 
+raw"\begin{align}
+\frac{dm_1}{dt} =& \frac{\alpha \cdot K^{n}}{K^{n} + D_2^{n}} - \delta \cdot m_1 + \gamma \\
+\frac{dm_2}{dt} =& \frac{\alpha \cdot K^{n}}{K^{n} + D_1^{n}} - \delta \cdot m_2 + \gamma \\
+\frac{dP_1}{dt} =& \beta \cdot m_1 - \mu \cdot P_1 -2 \cdot k_+ \cdot \frac{P_1^{2}}{2} + 2 \cdot k_- \cdot D_1 - k_+ \cdot P_1 \cdot P_2 + k_- \cdot T \\
+\frac{dP_2}{dt} =& \beta \cdot m_2 - \mu \cdot P_2 -2 \cdot k_+ \cdot \frac{P_2^{2}}{2} + 2 \cdot k_- \cdot D_2 - k_+ \cdot P_1 \cdot P_2 + k_- \cdot T \\
+\frac{dD_1}{dt} =& k_+ \cdot \frac{P_1^{2}}{2} - k_- \cdot D_1 \\
+\frac{dD_2}{dt} =& k_+ \cdot \frac{P_2^{2}}{2} - k_- \cdot D_2 \\
+\frac{dT}{dt} =& k_+ \cdot P_1 \cdot P_2 - k_- \cdot T \\
+\end{align}
+"
+
+@test latexify(rn; env=:chemical, cdot=false) == 
+raw"\begin{align}
+\require{mhchem}
+\ce{ \varnothing &->[\frac{\alpha K^{n}}{K^{n} + D_2^{n}}] m_{1}}\\
+\ce{ \varnothing &->[\frac{\alpha K^{n}}{K^{n} + D_1^{n}}] m_{2}}\\
+\ce{ m_{1} &<=>[\delta][\gamma] \varnothing}\\
+\ce{ m_{2} &<=>[\delta][\gamma] \varnothing}\\
+\ce{ m_{1} &->[\beta] m_{1} + P_{1}}\\
+\ce{ m_{2} &->[\beta] m_{2} + P_{2}}\\
+\ce{ P_{1} &->[\mu] \varnothing}\\
+\ce{ P_{2} &->[\mu] \varnothing}\\
+\ce{ 2 P_1 &<=>[k_{+}][k_{-}] D_{1}}\\
+\ce{ 2 P_2 &<=>[k_{+}][k_{-}] D_{2}}\\
+\ce{ P_{1} + P_{2} &<=>[k_{+}][k_{-}] T}
+\end{align}
+"
+
+@test latexify(rn; env=:chemical, cdot=true) == 
+raw"\begin{align}
+\require{mhchem}
+\ce{ \varnothing &->[\frac{\alpha \cdot K^{n}}{K^{n} + D_2^{n}}] m_{1}}\\
+\ce{ \varnothing &->[\frac{\alpha \cdot K^{n}}{K^{n} + D_1^{n}}] m_{2}}\\
+\ce{ m_{1} &<=>[\delta][\gamma] \varnothing}\\
+\ce{ m_{2} &<=>[\delta][\gamma] \varnothing}\\
+\ce{ m_{1} &->[\beta] m_{1} + P_{1}}\\
+\ce{ m_{2} &->[\beta] m_{2} + P_{2}}\\
+\ce{ P_{1} &->[\mu] \varnothing}\\
+\ce{ P_{2} &->[\mu] \varnothing}\\
+\ce{ 2 \cdot P_1 &<=>[k_{+}][k_{-}] D_{1}}\\
+\ce{ 2 \cdot P_2 &<=>[k_{+}][k_{-}] D_{2}}\\
+\ce{ P_{1} + P_{2} &<=>[k_{+}][k_{-}] T}
+\end{align}
+"
+
+# tabular
+@test latexify(rn.symjac; env=:tabular, cdot=false) == 
+raw"\begin{tabular}{ccccccc}
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
+$\beta$ & $0$ & $ - \mu - 2 k_+ P_1 - k_+ P_2$ & $ - k_+ P_1$ & $2 k_-$ & $0$ & $k_{-}$\\
+$0$ & $\beta$ & $ - k_+ P_2$ & $ - \mu - k_+ P_1 - 2 k_+ P_2$ & $0$ & $2 k_-$ & $k_{-}$\\
+$0$ & $0$ & $k_+ P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
+$0$ & $0$ & $0$ & $k_+ P_2$ & $0$ & $ - k_-$ & $0$\\
+$0$ & $0$ & $k_+ P_2$ & $k_+ P_1$ & $0$ & $0$ & $ - k_-$\\
+\end{tabular}
+"
+
+@test latexify(rn.symjac; env=:tabular, cdot=true) == 
+raw"\begin{tabular}{ccccccc}
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
+$\beta$ & $0$ & $ - \mu - 2 \cdot k_+ \cdot P_1 - k_+ \cdot P_2$ & $ - k_+ \cdot P_1$ & $2 \cdot k_-$ & $0$ & $k_{-}$\\
+$0$ & $\beta$ & $ - k_+ \cdot P_2$ & $ - \mu - k_+ \cdot P_1 - 2 \cdot k_+ \cdot P_2$ & $0$ & $2 \cdot k_-$ & $k_{-}$\\
+$0$ & $0$ & $k_+ \cdot P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
+$0$ & $0$ & $0$ & $k_+ \cdot P_2$ & $0$ & $ - k_-$ & $0$\\
+$0$ & $0$ & $k_+ \cdot P_2$ & $k_+ \cdot P_1$ & $0$ & $0$ & $ - k_-$\\
+\end{tabular}
+"
+
+# mdtable
+arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]
+
+@test latexify(arr; env=:mdtable, cdot=false) == 
+Markdown.md"| $x \left( y - 1 \right)$ |
+| ------------------------:|
+|                    $1.0$ |
+|                      $6$ |
+|                $x - 2 y$ |
+|                   $symb$ |
+"
+
+@test latexify(arr; env=:mdtable, cdot=true) == 
+Markdown.md"| $x \cdot \left( y - 1 \right)$ |
+| ------------------------------:|
+|                          $1.0$ |
+|                            $6$ |
+|                $x - 2 \cdot y$ |
+|                         $symb$ |
+"
+
+
+
+

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -69,8 +69,6 @@ raw"\begin{align}
 "
 
 # reactions
-if VERSION >= v"1.0"
-
 rn = @reaction_network begin
     hillr(D₂,α,K,n), ∅ --> m₁
     hillr(D₁,α,K,n), ∅ --> m₂
@@ -146,8 +144,8 @@ raw"\begin{align}
 # tabular
 @test latexify(rn.symjac; env=:tabular, cdot=false) == 
 raw"\begin{tabular}{ccccccc}
-$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_2^{-1 + n}}{\left( D_2^{n} + K^{n} \right)^{2}}$ & $0$\\
-$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_1^{-1 + n}}{\left( D_1^{n} + K^{n} \right)^{2}}$ & $0$ & $0$\\
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} n \alpha D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
 $\beta$ & $0$ & $ - \mu - 2 k_+ P_1 - k_+ P_2$ & $ - k_+ P_1$ & $2 k_-$ & $0$ & $k_{-}$\\
 $0$ & $\beta$ & $ - k_+ P_2$ & $ - \mu - k_+ P_1 - 2 k_+ P_2$ & $0$ & $2 k_-$ & $k_{-}$\\
 $0$ & $0$ & $k_+ P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
@@ -158,8 +156,8 @@ $0$ & $0$ & $k_+ P_2$ & $k_+ P_1$ & $0$ & $0$ & $ - k_-$\\
 
 @test latexify(rn.symjac; env=:tabular, cdot=true) == 
 raw"\begin{tabular}{ccccccc}
-$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_2^{-1 + n}}{\left( D_2^{n} + K^{n} \right)^{2}}$ & $0$\\
-$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_1^{-1 + n}}{\left( D_1^{n} + K^{n} \right)^{2}}$ & $0$ & $0$\\
+$ - \delta$ & $0$ & $0$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_2^{-1 + n}}{\left( K^{n} + D_2^{n} \right)^{2}}$ & $0$\\
+$0$ & $ - \delta$ & $0$ & $0$ & $\frac{ - K^{n} \cdot n \cdot \alpha \cdot D_1^{-1 + n}}{\left( K^{n} + D_1^{n} \right)^{2}}$ & $0$ & $0$\\
 $\beta$ & $0$ & $ - \mu - 2 \cdot k_+ \cdot P_1 - k_+ \cdot P_2$ & $ - k_+ \cdot P_1$ & $2 \cdot k_-$ & $0$ & $k_{-}$\\
 $0$ & $\beta$ & $ - k_+ \cdot P_2$ & $ - \mu - k_+ \cdot P_1 - 2 \cdot k_+ \cdot P_2$ & $0$ & $2 \cdot k_-$ & $k_{-}$\\
 $0$ & $0$ & $k_+ \cdot P_1$ & $0$ & $ - k_-$ & $0$ & $0$\\
@@ -167,8 +165,6 @@ $0$ & $0$ & $0$ & $k_+ \cdot P_2$ & $0$ & $ - k_-$ & $0$\\
 $0$ & $0$ & $k_+ \cdot P_2$ & $k_+ \cdot P_1$ & $0$ & $0$ & $ - k_-$\\
 \end{tabular}
 "
-
-end
 
 # mdtable
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]

--- a/test/chemical_arrows_test.jl
+++ b/test/chemical_arrows_test.jl
@@ -77,4 +77,4 @@ raw"\begin{align}
 "
 
 
-@test_throws MethodError latexify(rn; env=:arrow, bad_kwarg="should error")
+# @test_throws MethodError latexify(rn; env=:arrow, bad_kwarg="should error")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,3 +19,4 @@ using Test
 @testset "chemical_arrows test" begin include("chemical_arrows_test.jl") end
 @testset "DataFrame Plugin" begin include("plugins/DataFrames.jl") end
 @testset "unocode2latex" begin include("unicode2latex.jl") end
+@testset "cdot test" begin include("cdot_test.jl") end


### PR DESCRIPTION
This adds a `usecdot` kwarg to `latexify`. The default is true, which should not result in any changes in generated Latex, but if set to `false` will cause `latexraw` to just insert a single space within products instead of a \cdot.

I tried to forward kwargs everywhere it looked like this would change behavior, but please do let me know if I've missed anything and I can update the PR.