### PR TITLE
Disable clean_substitutions by default.

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -36,6 +36,8 @@ keyword_arguments = [
     KeywordArgument(:fmt, [:mdtable, :tabular, :align, :array, :raw, :inline], "format string", "`\"\"`", "Format number output in accordence with Printf. Example: \"%.2e\"", [:Any]),
     KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
     KeywordArgument(:convert_unicode, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Convert unicode characters to latex commands, for example `α` to `\\alpha`", [:Any]),
+    KeywordArgument(:symbolic, [:align], "`Bool`", "`false`", "Use symbolic calculations to clean up the expression.", [:ReactionNetwork]),
+    KeywordArgument(:clean, [:align], "`Bool`", "`false`", "Clean out `1*` terms. Only useful for DiffEqBiological versions 3.4 or below.", [:ReactionNetwork]),
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
     ]
 

--- a/src/plugins/DiffEqBiological.jl
+++ b/src/plugins/DiffEqBiological.jl
@@ -20,11 +20,20 @@ Generate an align environment from a reaction network.
 - noise::Bool - output the noise function?
 - symbolic::Bool - use symbolic calculation to reduce the expression?
 - bracket::Bool - Surround the variables with square brackets to denote concentrations.
+- clean::Bool - Clean out redundant "1*". Only useful for DiffEqBiological@v3.4.2 or earlier.
 """
-function latexalign(r::DiffEqBase.AbstractReactionNetwork; bracket=false, noise=false, symbolic=false, kwargs...)
+function latexalign(r::DiffEqBase.AbstractReactionNetwork; bracket=false, noise=false, symbolic=false, clean=false, kwargs...)
     lhs = [Meta.parse("d$x/dt") for x in r.syms]
     if !noise
-        symbolic ? (rhs = r.f_symfuncs) : (rhs = clean_subtractions.(r.f_func))
+        if symbolic
+            rhs = r.f_symfuncs
+        else
+            if clean
+                rhs = clean_subtractions.(r.f_func)
+            else
+                rhs = r.f_func
+            end
+        end
     else
         vec = r.g_func
         M = reshape(vec, :, length(r.syms))
@@ -99,7 +108,7 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
         str *= "}$eol"
     end
     str = str[1:end-length(eol)] * "\n"
-    
+
     str *= starred ? "\\end{align*}\n" : "\\end{align}\n"
 
     latexstr = LaTeXString(str)
@@ -116,6 +125,9 @@ Replace additions of negative terms with subtractions.
 
 This is a fairly stupid function which is designed for a specific problem
 with reaction networks. It is neither recursive nor very general.
+
+Note: this function was moved to DiffEqBiological and is only retained here for
+compatibility with older versions.
 
 Return :: cleaned out expression
 """
@@ -141,4 +153,9 @@ function clean_subtractions(ex::Expr)
         end
     end
     return result
+end
+
+function clean_subtractions(arg)
+    @warn "It appears that you are using a version of DiffEqBiological which does not require the latexify `clean` keyword argument. The `clean=true` specification will be ignored."
+    return arg
 end

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -36,7 +36,7 @@ rn = @reaction_network TestAlignMyRnType begin
   (r_b, r_u), x ↔ y
 end v_x k_x p_y d_x d_y r_b r_u
 
-@test latexalign(rn).s ==
+@test latexalign(rn; clean=true).s ==
 raw"\begin{align}
 \frac{dx}{dt} =& \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} - d_{x} \cdot x - r_{b} \cdot x + r_{u} \cdot y \\
 \frac{dy}{dt} =& p_{y} - d_{y} \cdot y + r_{b} \cdot x - r_{u} \cdot y \\


### PR DESCRIPTION
`clean_substitutions` has been moved to DiffEqBiological itself. This
creates a kwarg to toggle the cleaning within latexify and it generates
a warning if improperly used.