### PR TITLE
Added Functionality for NumberFormatters

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -11,6 +11,8 @@ export latexify, md, copy_to_clipboard, auto_display
 ## Allow some backwards compatibility until its time to deprecate.
 export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
 
+export StyledNumberFormatter, FancyNumberFormatter
+
 COPY_TO_CLIPBOARD = false
 function copy_to_clipboard(x::Bool)
     global COPY_TO_CLIPBOARD = x
@@ -35,6 +37,8 @@ include("mdtable.jl")
 include("mdtext.jl")
 
 include("utils.jl")
+
+include("numberformatters.jl")
 
 
 ### Add support for additional packages without adding them as dependencies.

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -7,10 +7,11 @@ This uses the information about the previous operations to decide if
 a parenthesis is needed.
 
 """
-function latexoperation(ex::Expr, prevOp::AbstractArray)
+function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)
     op = ex.args[1]
     convertSubscript!(ex)
-    args = ex.args
+    args = map(i -> i isa Number ? latexraw(i; kwargs...) : i, ex.args)
+
     if op in [:/, :./]
         return "\\frac{$(args[2])}{$(args[3])}"
 

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -68,12 +68,12 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                 ex.args[i] = recurseexp!(ex.args[i])
             end
         end
-        return latexoperation(ex, prevOp)
+        return latexoperation(ex, prevOp; kwargs...)
     end
     ex = deepcopy(inputex)
     str = recurseexp!(ex)
     convert_unicode && (str = unicode2latex(str))
-    LaTeXString(str)
+    return LaTeXString(str)
 end
 
 
@@ -86,12 +86,16 @@ latexraw(z::Complex; kwargs...) = LaTeXString("$(z.re)$(z.im < 0 ? "" : "+" )$(z
 #latexraw(i::DataFrames.DataArrays.NAtype) = "\\textrm{NA}"
 latexraw(str::LaTeXStrings.LaTeXString; kwargs...) = str
 
-function latexraw(i::Number; fmt="", kwargs...)
-    if fmt == ""
-        return string(i)
-    else
-        return @eval @sprintf($fmt, $i)
-    end
+#function latexraw(i::Number; fmt="", kwargs...)
+#    if fmt == ""
+#        return string(i)
+#    else
+#        return @eval @sprintf($fmt, $i)
+#    end
+#end
+
+function latexraw(i::Number; fmt="", number_formatter = fmt=="" ? PlainNumberFormatter() : PrintfNumberFormatter(fmt), kwargs...)
+    return number_formatter(i)
 end
 
 function latexraw(i::Char; convert_unicode=true, kwargs...)

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -1,6 +1,6 @@
 abstract type AbstractNumberFormatter end
 
-const float_regex = r"(?'mantissa'(?'before_dp'(?'sign'-?)(?'before_dp_nosign'\d+))(\.(?'after_dp'\d+))?)(?'e_or_E'e)(?'raw_exp'\+?0*(?'exp'(?'sign_exp'-?)\d+))"
+const float_regex = r"(?'mantissa'(?'before_dp'(?'sign'-?)(?'before_dp_nosign'\d+))(\.(?'after_dp'\d+))?)(?'e_or_E'e)(?'raw_exp'\+?0*(?'exp'(?'sign_exp'-?)\d+))"i
 
 struct PlainNumberFormatter <: AbstractNumberFormatter end
 

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -1,0 +1,61 @@
+abstract type AbstractNumberFormatter end
+
+const float_regex = r"(?'mantissa'(?'before_dp'(?'sign'-?)(?'before_dp_nosign'\d+))(\.(?'after_dp'\d+))?)(?'e_or_E'e)(?'raw_exp'\+?0*(?'exp'(?'sign_exp'-?)\d+))"
+
+struct PlainNumberFormatter <: AbstractNumberFormatter end
+
+(::PlainNumberFormatter)(x) = string(x)
+
+
+struct PrintfNumberFormatter <: AbstractNumberFormatter
+    fmt::String
+end
+
+(f::PrintfNumberFormatter)(x) = @eval @sprintf $(f.fmt) $x
+
+
+struct StyledNumberFormatter <: AbstractNumberFormatter
+    fmt::String
+
+    StyledNumberFormatter(fmt::String="%.4g") = new(fmt)
+
+end
+
+function StyledNumberFormatter(significant_digits::Int)
+    return StyledNumberFormatter("%.$(significant_digits)g")
+end
+
+(f::StyledNumberFormatter)(x) = string(x)
+function (f::StyledNumberFormatter)(x::AbstractFloat)
+    s = @eval @sprintf $(f.fmt) $x
+    return replace(s, float_regex => s"\g<mantissa> \\mathrm{\g<e_or_E>} \g<exp>")
+end
+
+(f::StyledNumberFormatter)(x::Unsigned) = "\\mathtt{0x$(string(x; base=16, pad=2sizeof(x)))}"
+
+
+struct FancyNumberFormatter <: AbstractNumberFormatter
+    fmt::String
+    exponent_format::SubstitutionString
+
+    function FancyNumberFormatter(fmt::String="%.4g",
+                                  exponent_format::SubstitutionString=s"\g<mantissa> \\cdot 10^{\g<exp>}")
+        return new(fmt, exponent_format)
+    end
+end
+
+function FancyNumberFormatter(fmt::String, mult_symbol)
+    return FancyNumberFormatter(fmt, SubstitutionString("\\g<mantissa> $(escape_string(mult_symbol)) 10^{\\g<exp>}"))
+end
+function FancyNumberFormatter(significant_digits, mult_symbol="\\cdot")
+    return FancyNumberFormatter("%.$(significant_digits)g", mult_symbol)
+end
+
+(f::FancyNumberFormatter)(x) = string(x)
+
+function (f::FancyNumberFormatter)(x::AbstractFloat)
+    s = @eval @sprintf $(f.fmt) $x
+    return replace(s, float_regex => f.exponent_format)
+end
+
+(f::FancyNumberFormatter)(x::Unsigned) = "\\mathtt{0x$(string(x; base=16, pad=2sizeof(x)))}"

--- a/test/numberformatters_test.jl
+++ b/test/numberformatters_test.jl
@@ -1,0 +1,17 @@
+using Latexify
+using Test
+import Latexify: PlainNumberFormatter, PrintfNumberFormatter
+
+@test FancyNumberFormatter() == FancyNumberFormatter(4) == FancyNumberFormatter("%.4g", "\\cdot") == FancyNumberFormatter("%.4g", s"\g<mantissa> \\cdot 10^{\g<exp>}")
+
+x = -23.4728979e7
+
+@test PlainNumberFormatter()(x) == "-2.34728979e8"
+@test PrintfNumberFormatter("%.4g")(x) == "-2.347e+08"
+@test StyledNumberFormatter()(x) == "-2.347 \\mathrm{e} 8"
+@test FancyNumberFormatter()(x) == "-2.347 \\cdot 10^{8}"
+@test FancyNumberFormatter("%.5E", s"\g<mantissa>,\g<before_dp>,\g<sign>,\g<before_dp_nosign>,\g<after_dp>,\g<e_or_E>,\g<raw_exp>,\g<exp>,\g<sign_exp>")(x) == "-2.34729,-2,-,2,34729,E,+08,8,"
+
+y = 0xf43
+
+@test StyledNumberFormatter()(y) == FancyNumberFormatter()(y) == "\\mathtt{0x0f43}"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,4 +18,5 @@ using Test
 @testset "mdtable tests" begin include("mdtable_test.jl") end
 @testset "chemical_arrows test" begin include("chemical_arrows_test.jl") end
 @testset "DataFrame Plugin" begin include("plugins/DataFrames.jl") end
-@testset "unocode2latex" begin include("unicode2latex.jl") end
+@testset "unicode2latex" begin include("unicode2latex.jl") end
+@testset "numberformatters" begin include("numberformatters_test.jl") end


### PR DESCRIPTION
After this PR, it will be possible to specify `NumberFormatter`s to `latexraw`. `latexraw` can still be used exactly the same and will behave like it did, but if the keyword `number_formatter` is specified, `latexraw` will use it to format numbers. This makes it possible to have much nicer printing for floats and UInts. Eventually it might be a good idea to use `StyledNumberFormatter` by default, because the `e` in floats otherwise looks pretty ugly, but that would be breaking and I didn't want to make such a decision on my own. `latexoperation` now also calls `latexraw` on arguments that are numbers and passes `kwargs`. I was kind of surprised, it didn't do that already. It didn't break any tests, but there might be some corner cases, where the behavior will be slightly different. I haven't added any documentation yet, but might make another PR if I find the time.