### PR TITLE
Add support for env=:equation.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,7 +3,7 @@ using Latexify
 
 makedocs(
     modules = [Latexify],
-    format = :html,
+    format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
     sitename = "Latexify.jl",
     pages = [
         "index.md",
@@ -27,9 +27,7 @@ makedocs(
 deploydocs(
     #deps = Deps.pip("mkdocs", "python-markdown-math"),
     repo = "github.com/korsbo/Latexify.jl.git",
-    julia  = "1.1",
     target = "build",
-    osname = "linux",
     make = nothing,
     deps = nothing
     )

--- a/docs/src/arguments.md
+++ b/docs/src/arguments.md
@@ -7,6 +7,12 @@ args = [arg for arg in keyword_arguments if :align in arg.env]
 latexify(args, env=:mdtable)
 ```
 
+## Equation
+```@eval
+Base.include(@__MODULE__, "src/table_generator.jl")
+args = [arg for arg in keyword_arguments if :equation in arg.env]
+latexify(args, env=:mdtable)
+```
 
 ## Array
 ```@eval

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,6 +57,7 @@ However, you can override this by passing the keyword argument `env = `. The fol
 | no env | `:raw` | Latexifies an object and returns a ``\LaTeX`` formatted string. If the input is an array it will be recursed and all its elements latexified. This function does not surround the resulting string in any ``\LaTeX`` environments.
 | Inline | `:inline` | latexify the input and surround it with $$ for inline rendering. |
 | Align | `:align` | Latexifies input and surrounds it with an align environment. Useful for systems of equations and such fun stuff. |
+| Equation | `:equation` or `:eq` | Latexifies input and surrounds it with an equation environment. |
 | Array | `:array` | Latexify the elements of an Array or a Dict and output them in a ``\LaTeX`` array. |
 | Tabular | `:table` or `:tabular` | Latexify the elements of an array and output a tabular environment. Note that tabular is not supported by MathJax and will therefore not be rendered in Jupyter, etc.|
 | Markdown Table | `:mdtable` | Output a Markdown table. This will be rendered nicely by Jupyter, etc. |

--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -21,7 +21,7 @@ end
 
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
 keyword_arguments = [
-    KeywordArgument(:starred, [:align, :array, :arrow], "`Bool`", "`false`", "Star the environment to prevent equation numbering.", [:Any]),
+    KeywordArgument(:starred, [:align, :array, :arrow, :equation], "`Bool`", "`false`", "Star the environment to prevent equation numbering.", [:Any]),
     KeywordArgument(:separator, [:align], "`String`", "`\" =& \"`", "Specify how to separate the left hand side and the right.", [:Any]),
     KeywordArgument(:transpose, [:array, :tabular, :mdtable], "`Bool`", "`true`", "Flip rows for columns.", [:Any]),
     KeywordArgument(:double_linebreak, [:array, :align, :arrow], "`Bool`", "`false`", "Add an extra `\\\\` to the end of the line.", [:Any]),
@@ -36,7 +36,7 @@ keyword_arguments = [
     KeywordArgument(:fmt, [:mdtable, :tabular, :align, :array, :raw, :inline], "format string", "`\"\"`", "Format number output in accordence with Printf. Example: \"%.2e\"", [:Any]),
     KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
     KeywordArgument(:convert_unicode, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Convert unicode characters to latex commands, for example `α` to `\\alpha`", [:Any]),
-    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\cdot` or just a space to represent multiplication.", [:Any]),
+    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\\cdot` or just a space to represent multiplication.", [:Any]),
     KeywordArgument(:symbolic, [:align], "`Bool`", "`false`", "Use symbolic calculations to clean up the expression.", [:ReactionNetwork]),
     KeywordArgument(:clean, [:align], "`Bool`", "`false`", "Clean out `1*` terms. Only useful for DiffEqBiological versions 3.4 or below.", [:ReactionNetwork]),
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -28,6 +28,7 @@ include("latexify_function.jl")
 include("latexarray.jl")
 include("latexalign.jl")
 include("latexinline.jl")
+include("latexequation.jl")
 include("latextabular.jl")
 
 include("md.jl")

--- a/src/latexequation.jl
+++ b/src/latexequation.jl
@@ -1,0 +1,15 @@
+
+function latexequation end
+
+function latexequation(eq; starred=false, kwargs...)
+    latexstr = latexraw(eq; kwargs...)
+
+    str = "\\begin{equation$(starred ? "*" : "")}\n"
+    str *= latexstr
+    str *= "\n"
+    str *= "\\end{equation$(starred ? "*" : "")}\n"
+    latexstr = LaTeXString(str)
+    COPY_TO_CLIPBOARD && clipboard(latexstr)
+    return latexstr
+end
+

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -16,6 +16,7 @@ function infer_output(env, args...)
         env == :raw && return latexraw
         env == :array && return latexarray
         env == :align && return latexalign
+        env in [:eq, :equation] && return latexequation
         env == :mdtable && return mdtable
         env == :mdtext && return mdtext
         env in [:arrows, :chem, :chemical, :arrow] && return chemical_arrows

--- a/test/latexequation_test.jl
+++ b/test/latexequation_test.jl
@@ -1,0 +1,12 @@
+
+@test latexify("x/y"; env=:eq) == 
+raw"\begin{equation}
+\frac{x}{y}
+\end{equation}
+"
+
+@test latexify("x = a^x/b"; env=:eq, starred=true) == 
+raw"\begin{equation*}
+x = \frac{a^{x}}{b}
+\end{equation*}
+"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using Test
 @testset "latexraw tests" begin include("latexraw_test.jl") end
 @testset "latexalign tests" begin include("latexalign_test.jl") end
 @testset "latexarray tests" begin include("latexarray_test.jl") end
+@testset "latexequation tests" begin include("latexequation_test.jl") end
 @testset "latexinline tests" begin include("latexinline_test.jl") end
 @testset "latextabular tests" begin include("latextabular_test.jl") end
 @testset "mdtable tests" begin include("mdtable_test.jl") end


### PR DESCRIPTION
When using Weave.jl, I found myself missing the option of outputting a 
```latex
\begin{equation}
...
\end{equation}
```
environment. This PR remedies this.

- [x] Add the code for this. 
- [x] Update the docs.
- [x] Add  tests. 
