### PR TITLE
Add support for ModelingToolkit.jl

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -46,6 +46,9 @@ function __init__()
     @require DiffEqBiological = "eb300fae-53e8-50a0-950c-e21f52c2b7e0" begin
         include(joinpath("plugins", "DiffEqBiological.jl"))
     end
+    @require ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78" begin
+        include(joinpath("plugins", "ModelingToolkit.jl"))
+    end
     @require SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8" begin
         include(joinpath("plugins", "SymEngine.jl"))
     end

--- a/src/plugins/ModelingToolkit.jl
+++ b/src/plugins/ModelingToolkit.jl
@@ -1,0 +1,30 @@
+
+##################################################
+#   Override default handling (default = inline) #
+##################################################
+get_latex_function(eqs::Vector{ModelingToolkit.Equation}) = latexalign
+
+get_md_function(eqs::Vector{ModelingToolkit.Equation}) = mdalign
+
+###############################################
+#         Overload environment functions      #
+###############################################
+
+function latexalign(eqs::Vector{ModelingToolkit.Equation}; iw=:t, kwargs...)
+    rhs = getfield.(eqs, :rhs)
+    rhs = convert.(Expr, rhs)
+    rhs = [postwalk(x -> x isa ModelingToolkit.Constant ? x.value : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential ? "\\frac{d\\left($(latexraw(x.args[2]))\\right)}{d$iv}" : x, eq) for eq in rhs]
+    
+    lhs = getfield.(eqs, :lhs)
+    lhs = convert.(Expr, lhs)
+    lhs = [postwalk(x -> x isa ModelingToolkit.Constant ? x.value : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential ? "\\frac{d\\left($(latexraw(x.args[2]))\\right)}{d$iv}" : x, eq) for eq in lhs]
+   
+
+    latexify(lhs, rhs; kwargs...)
+end


### PR DESCRIPTION
- [x] code
- [ ] tests
- [ ] documentation

It is mostly functional already.

```julia
using Latexify
using ModelingToolkit

@parameters t σ ρ β
@variables x(t) y(t) z(t)
@derivatives D'~t

eqs = [D(x) ~ σ*(y-x)*D(x-y)/D(z),
       0 ~ σ*x*(ρ-z)/10-y,
       D(z) ~ x*y - β*z]

latexify(eqs; iv=:t)
```

$$
\begin{align}
\frac{dx(t)}{dt} =& \frac{\sigma \cdot \left( \mathrm{y}\left( t \right) - \mathrm{x}\left( t \right) \right) \cdot \frac{d\left(\mathrm{x}\left( t \right) - \mathrm{y}\left( t \right)\right)}{dt}}{\frac{dz(t)}{dt}} \\
0 =& \frac{\sigma \cdot \mathrm{x}\left( t \right) \cdot \left( \rho - \mathrm{z}\left( t \right) \right)}{10} - \mathrm{y}\left( t \right) \\
\frac{dz(t)}{dt} =& \mathrm{x}\left( t \right) \cdot \mathrm{y}\left( t \right) - \beta \cdot \mathrm{z}\left( t \right)
\end{align}
$$

![image](https://user-images.githubusercontent.com/16306680/61215325-779c0e80-a702-11e9-8e3c-ebb35925279d.png)


### Remaining problems
- I'm letting the user supply a single independent variable as a kwarg. This will not work with PDEs and it's less elegant than I'd like.
- The output is not consistent with that of `@ode_def` or `@reaction_network`.
  - variables are surrounded by `\textrm{}` (I don't mind but I dislike inconsistency).
  - the independent variable is shown `x(t)`. 
  - brackets are not supported.
- Variables are in italics when they are in derivatives but not otherwise.
- ModelingToolkit represents the derivative in two different ways for my two different environments (Julia 1.1 and 1.2-rc2) only one of them works correctly. I'm guessing that this is a problem with ModelingToolkit and I don't want to hack together a fix here. 1.1 gives something like `Equation((D'~t())(z(t()))` while 1.2 gives `Equation(Differential(z(t)))`.  

