### PR TITLE
Redefine default orientation vectors in env=:array

### DIFF
--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -12,10 +12,12 @@ latexarray(arr)
 "\\begin{equation}\n\\left[\n\\begin{array}{cc}\n1 & 2\\\\ \n3 & 4\\\\ \n\\end{array}\n\\right]\n\\end{equation}\n"
 ```
 """
-function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false, double_linebreak=false,
+function latexarray(arr::AbstractArray; adjustment::Symbol=:c, transpose=false, double_linebreak=false,
     starred=false, kwargs...)
-    transpose && (arr = permutedims(arr, [2,1]))
-    (rows, columns) = size(arr)
+    transpose && (arr = permutedims(arr))
+    rows = first(size(arr))
+    columns = length(size(arr)) > 1 ? size(arr)[2] : 1
+
     eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
 
     str = "\\begin{equation$(starred ? "*" : "")}\n"
@@ -37,8 +39,13 @@ function latexarray(arr::AbstractMatrix; adjustment::Symbol=:c, transpose=false,
 end
 
 
-latexarray(vec::AbstractVector; kwargs...) = latexarray(hcat(vec...); kwargs...)
 latexarray(args::AbstractArray...; kwargs...) = latexarray(hcat(args...); kwargs...)
 latexarray(arg::AbstractDict; kwargs...) = latexarray(collect(keys(arg)), collect(values(arg)); kwargs...)
-latexarray(arg::Tuple; kwargs...) = latexarray([collect(i) for i in arg]; kwargs...)
-latexarray(arg::Tuple...; kwargs...) = latexarray([collect(i) for i in arg]; kwargs...)
+latexarray(arg::Tuple...; kwargs...) = latexarray([collect(i) for i in arg]...; kwargs...)
+
+function latexarray(arg::Tuple; kwargs...) 
+    if first(arg) isa Tuple || first(arg) isa AbstractArray
+        return latexarray([collect(i) for i in arg]...; kwargs...)
+    end
+    return latexarray(collect(arg); kwargs...)
+end

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -28,7 +28,7 @@ raw"x \left( y + z \right) y \left( z + a \right) \left( z + b \right)"
 raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)"
 
 # array
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, cdot=false) ==
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, transpose=true, cdot=false) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -38,7 +38,7 @@ x y & x \left( y + z \right) y \left( z + a \right) \left( z + b \right) \\
 \end{equation}
 "
 
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, cdot=true) == 
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, transpose=true, cdot=true) == 
 raw"\begin{equation}
 \left[
 \begin{array}{cc}

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -1,4 +1,5 @@
 using Latexify
+using Test
 
 arr = [1 2; 3 4]
 
@@ -16,7 +17,7 @@ raw"\begin{equation}
 
 arr = [1,2,:(x/y),4]
 
-@test latexify(arr; transpose=true) ==
+@test latexify(arr) ==
 raw"\begin{equation}
 \left[
 \begin{array}{c}
@@ -29,6 +30,15 @@ raw"\begin{equation}
 \end{equation}
 "
 
+@test latexify(arr; transpose=true) == 
+raw"\begin{equation}
+\left[
+\begin{array}{cccc}
+1 & 2 & \frac{x}{y} & 4 \\
+\end{array}
+\right]
+\end{equation}
+"
 
 @test latexify((1.0, 2), (3, 4)) ==
 raw"\begin{equation}
@@ -40,7 +50,6 @@ raw"\begin{equation}
 \right]
 \end{equation}
 "
-
 
 @test latexify(((1.0, 2), (3, 4))) ==
 raw"\begin{equation}

--- a/test/unicode2latex.jl
+++ b/test/unicode2latex.jl
@@ -1,7 +1,7 @@
 @test latexify("α"; convert_unicode=false) == raw"$α$"
 
 
-@test latexify(['α', :β, "γ/η"], convert_unicode=false) ==
+@test latexify(['α', :β, "γ/η"], transpose=true, convert_unicode=false) ==
 raw"\begin{equation}
 \left[
 \begin{array}{ccc}


### PR DESCRIPTION
See #67. 

This is a breaking change and it affects how vectors and tuples are represented in the `:array` environment.