### PR TITLE
WIP: Add post-processing hook.

### DIFF
--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -41,9 +41,8 @@ julia> latexalign(ode)
 """
 function latexalign end
 
-function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false, kwargs...)
+function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n", starred=false, kwargs...)
     (rows, columns) = size(arr)
-    eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
     arr = latexraw(arr; kwargs...)
 
     str = "\\begin{align$(starred ? "*" : "")}\n"
@@ -52,9 +51,9 @@ function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=fals
     end
     str *= join(arr[end,:], separator) * "\n"  # No EOL on the last line.
     str *= "\\end{align$(starred ? "*" : "")}\n"
-    latexstr = LaTeXString(str)
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    #= latexstr = LaTeXString(str) =#
+    #= COPY_TO_CLIPBOARD && clipboard(latexstr) =#
+    return output(str; kwargs...)
 end
 
 function latexalign(lhs::AbstractArray, rhs::AbstractArray; kwargs...)

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -33,8 +33,6 @@ function latexarray(arr::AbstractArray; adjustment::Symbol=:c, transpose=false, 
     str *= "\\end{array}\n"
     str *= "\\right]\n"
     str *= "\\end{equation$(starred ? "*" : "")}\n"
-    #= latexstr = LaTeXString(str) =#
-    #= COPY_TO_CLIPBOARD && clipboard(latexstr) =#
     return output(str; kwargs...)
 end
 

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -33,9 +33,9 @@ function latexarray(arr::AbstractArray; adjustment::Symbol=:c, transpose=false, 
     str *= "\\end{array}\n"
     str *= "\\right]\n"
     str *= "\\end{equation$(starred ? "*" : "")}\n"
-    latexstr = LaTeXString(str)
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    #= latexstr = LaTeXString(str) =#
+    #= COPY_TO_CLIPBOARD && clipboard(latexstr) =#
+    return output(str; kwargs...)
 end
 
 

--- a/src/latexequation.jl
+++ b/src/latexequation.jl
@@ -8,8 +8,6 @@ function latexequation(eq; starred=false, kwargs...)
     str *= latexstr
     str *= "\n"
     str *= "\\end{equation$(starred ? "*" : "")}\n"
-    latexstr = LaTeXString(str)
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    return output(str; kwargs...)
 end
 

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -60,3 +60,13 @@ function get_latex_function(x::AbstractArray{T}) where T <: AbstractArray
 end
 
 get_latex_function(lhs::AbstractVector, rhs::AbstractVector) = latexalign
+
+
+function output(str; post_processing=x->x, escape_underscores=false, kwargs...)
+    str = post_processing(str)
+    str == nothing && return nothing
+    escape_underscores && (str = replace(str, "_"=>"\\_"))
+    latexstr = LaTeXString(str)
+    COPY_TO_CLIPBOARD && clipboard(latexstr)
+    return latexstr
+end

--- a/src/latexinline.jl
+++ b/src/latexinline.jl
@@ -1,7 +1,6 @@
 function latexinline(x; kwargs...)
     latexstr = latexstring( latexraw(x; kwargs...) )
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    return output(latexstr.s; kwargs...)
 end
 
 latexinline(x::Union{AbstractArray, Tuple}; kwargs...) = [ latexinline(i; kwargs...) for i in x]

--- a/src/latextabular.jl
+++ b/src/latextabular.jl
@@ -29,9 +29,7 @@ function latextabular(arr::AbstractMatrix; latex::Bool=true, head=[], side=[], a
     end
 
     str *= "\\end{tabular}\n"
-    latexstr = LaTeXString(str)
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    return output(str; kwargs...)
 end
 
 

--- a/src/plugins/DiffEqBiological.jl
+++ b/src/plugins/DiffEqBiological.jl
@@ -110,9 +110,7 @@ function chemical_arrows(rn::DiffEqBase.AbstractReactionNetwork;
 
     str *= starred ? "\\end{align*}\n" : "\\end{align}\n"
 
-    latexstr = LaTeXString(str)
-    COPY_TO_CLIPBOARD && clipboard(latexstr)
-    return latexstr
+    return output(str; kwargs...)
 end
 
 


### PR DESCRIPTION
This is a work in progress.

It adds a post-processing hook as a keyword argument that allows you to pass arbitrary functions which can modify the result just before it is outputted. It's a bit of a sledgehammer, but it has proven useful when I use Latexify for stuff that is automatically deployed to the web. In some cases, I have had to add additional escape characters or change the newline specification and this post-processing hook allows me to do that. 

```julia
function post_processing(str)
    str = replace(str, raw"\\"=>raw"\newline")
    return str
end

latexify(something; post_processing = post_processing)
```

