### PR TITLE
Use Formatting.jl to speed up printf.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.12.3"
+version = "0.13.0"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ repo = "https://github.com/korsbo/Latexify.jl.git"
 version = "0.12.3"
 
 [deps]
+Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -16,6 +17,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 LaTeXStrings = "0.3, 1"
 MacroTools = "0.4, 0.5"
 Requires = "0.5, 1.0"
+Formatting = "0.4"
 julia = "1"
 
 [extras]

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -5,6 +5,7 @@ using InteractiveUtils
 using Markdown
 using MacroTools: postwalk
 using Printf
+using Formatting
 
 export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
     reset_default, @latexrecipe

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -9,9 +9,10 @@ struct PlainNumberFormatter <: AbstractNumberFormatter end
 
 struct PrintfNumberFormatter <: AbstractNumberFormatter
     fmt::String
+    f::Function
 end
-
-(f::PrintfNumberFormatter)(x) = @eval @sprintf $(f.fmt) $x
+PrintfNumberFormatter(fmt::String) = PrintfNumberFormatter(fmt, Formatting.generate_formatter(fmt))
+(f::PrintfNumberFormatter)(x) = f.f(x)
 
 
 struct StyledNumberFormatter <: AbstractNumberFormatter


### PR DESCRIPTION
Ensures that the same printf number formatting operation does not need to be re-compiled for every single call. 

This adds a dependency to Formatting.jl

Closes #90 