### PR TITLE
Add macro for latexifying one-liner functions and add external rendering.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.13.1"
+version = "0.13.3"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.13.0"
+version = "0.13.1"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -200,7 +200,7 @@ lstr = @latexrun f(x; y=2) = x/y
 ```
 
 ## External rendering
-While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone pdf using LuaLaTeX and opens that file in your default PDF viewer. 
+While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone PDF using LuaLaTeX and opens that file in your default PDF viewer. 
 
 I have found the following syntax pretty useful:
 ```julia

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -188,7 +188,24 @@ and to reset your changes, use
 ```julia
 reset_default()
 ```
+## Macros
+Two macros are exported. 
 
+- `@latexify` simply latexifies the expression that you provide to it, similar to `latexify(:(...))`.
+- `@latexrun` both executes and latexifies the given expression. 
+
+They can for example be useful for latexifying simple mathsy functions like
+```julia
+lstr = @latexrun f(x; y=2) = x/y
+```
+
+## External rendering
+While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone pdf using LuaLaTeX and opens that file in your default PDF viewer. 
+
+I have found the following syntax pretty useful:
+```julia
+latexify(:(x/y)) |> render
+```
 
 ## Legacy support
 

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -8,7 +8,7 @@ using Printf
 using Formatting
 
 export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
-    reset_default, @latexrecipe
+    reset_default, @latexrecipe, render
 
 ## Allow some backwards compatibility until its time to deprecate.
 export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -8,7 +8,7 @@ using Printf
 using Formatting
 
 export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
-    reset_default, @latexrecipe, render
+    reset_default, @latexrecipe, render, @latexify
 
 ## Allow some backwards compatibility until its time to deprecate.
 export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
@@ -37,6 +37,7 @@ include("latexequation.jl")
 include("latextabular.jl")
 include("default_kwargs.jl")
 include("recipes.jl")
+include("macros.jl")
 
 include("md.jl")
 include("mdtable.jl")

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -8,7 +8,7 @@ using Printf
 using Formatting
 
 export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
-    reset_default, @latexrecipe, render, @latexify
+    reset_default, @latexrecipe, render, @latexify, @latexrun
 
 ## Allow some backwards compatibility until its time to deprecate.
 export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -132,6 +132,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     ex.head == :parameters && return join(args, ", ")
 
     ex.head == :block && length(args)==2 && return args[2]
+    ex.head == :block && return args[end]
     
     ## if we have reached this far without a return, then error.
     error("Latexify.jl's latexoperation does not know what to do with one of the

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -130,6 +130,8 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
 
     ex.head == :kw && return "$(ex.args[1]) = $(ex.args[2])"
     ex.head == :parameters && return join(args, ", ")
+
+    ex.head == :block && length(args)==2 && return args[2]
     
     ## if we have reached this far without a return, then error.
     error("Latexify.jl's latexoperation does not know what to do with one of the

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -114,7 +114,11 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     end
 
     if ex.head == :call
-        return "\\mathrm{$op}\\left( $(join(args[2:end], ", ")) \\right)"
+        if args[2] isa String && occursin("=", args[2])
+            return "\\mathrm{$op}\\left( $(join(args[3:end], ", ")); $(args[2]) \\right)"
+        else
+            return "\\mathrm{$op}\\left( $(join(args[2:end], ", ")) \\right)"
+        end
     end
 
     if ex.head == :tuple
@@ -123,9 +127,13 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     end
 
     ex.head == Symbol("'") && return "$(args[1])'"
+
+    ex.head == :kw && return "$(ex.args[1]) = $(ex.args[2])"
+    ex.head == :parameters && return join(args, ", ")
+    
     ## if we have reached this far without a return, then error.
     error("Latexify.jl's latexoperation does not know what to do with one of the
-                operators in your expression ($op).")
+          expressions provides ($ex).")
     return ""
 end
 

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -128,10 +128,12 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
 
     ex.head == Symbol("'") && return "$(args[1])'"
 
-    ex.head == :kw && return "$(ex.args[1]) = $(ex.args[2])"
+    ## Enable the parsing of kwargs in a function definition
+    ex.head == :kw && return "$(args[1]) = $(args[2])"
     ex.head == :parameters && return join(args, ", ")
 
-    ex.head == :block && length(args)==2 && return args[2]
+    ## Use the last expression in a block. 
+    ## This is somewhat shady but it helps with latexifying functions.
     ex.head == :block && return args[end]
     
     ## if we have reached this far without a return, then error.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,8 +1,7 @@
 macro latexify(oneliner)
-    rhs = oneliner.args[1]
-    lhs = oneliner.args[2].args[end]
     return quote
         $(esc(oneliner))
-        latexify($(string(rhs) * " = " * string(lhs)))
+        latexify($(string(oneliner)))
     end
 end
+

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,7 +1,13 @@
-macro latexify(oneliner)
+macro latexrun(expr)
     return quote
-        $(esc(oneliner))
-        latexify($(string(oneliner)))
+        $(esc(expr))
+        latexify($(string(expr)))
     end
 end
 
+
+macro latexify(expr)
+    return quote
+        latexify($(string(expr)))
+    end
+end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,4 +1,8 @@
 macro latexify(oneliner)
-    display(latexify(:($(oneliner.args[1]) = $(oneliner.args[2].args[2]))))
-    return oneliner
+    rhs = oneliner.args[1]
+    lhs = oneliner.args[2].args[end]
+    return quote
+        $(esc(oneliner))
+        latexify($(string(rhs) * " = " * string(lhs)))
+    end
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,0 +1,4 @@
+macro latexify(oneliner)
+    display(latexify(:($(oneliner.args[1]) = $(oneliner.args[2].args[2]))))
+    return oneliner
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,3 +9,43 @@ function add_brackets(ex::Expr, vars)
     ex = postwalk(x -> x in vars ? "\\left[ $(convertSubscript(x)) \\right]" : x, ex)
     return ex
 end
+
+
+"""
+    render(::LaTeXString; debug=false, name=tempname(), command="\\Large")
+
+Display a standalone PDF with the given input.
+"""
+function render(s::LaTeXString; debug=false, name=tempname(), command="\\Large")
+    doc = """
+    \\documentclass[varwidth]{standalone}
+    \\usepackage{amssymb}
+    \\usepackage{amsmath}
+    \\begin{document}
+    {
+        $command
+        $s
+    }
+    \\end{document}
+    """
+    doc = replace(doc, "\\begin{align}"=>"\\[\n\\begin{aligned}")
+    doc = replace(doc, "\\end{align}"=>"\\end{aligned}\n\\]")
+    open("$(name).tex", "w") do f
+        write(f, doc)
+    end
+    cd(dirname(name)) do 
+        cmd = `lualatex $(name).tex`
+        debug || (cmd = pipeline(cmd, devnull))
+        run(cmd)
+    end
+    if Sys.iswindows()
+        run(`cmd /c "start $(name).pdf"`, wait=false)
+    elseif Sys.islinux()
+        run(`xdg-open $(name).pdf`, wait=false)
+    elseif Sys.isapple()
+        run(`open $(name).pdf`, wait=false)
+    elseif Sys.isbsd()
+        run(`xdg-open $(name).pdf`, wait=false)
+    end
+    return nothing
+end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,0 +1,10 @@
+l = @latexify dummyfunc(x; y=1, z=3) = x^2/y + z
+@test l == raw"$\mathrm{dummyfunc}\left( x; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+
+@test_throws UndefVarError dummyfunc(1.) 
+
+l2 = @latexrun dummyfunc2(x; y=1, z=3) = x^2/y + z
+@test l2 == raw"$\mathrm{dummyfunc2}\left( x; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+
+@test dummyfunc2(1.) == 4
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
 
 # Run tests
 
+@testset "macro test" begin include("macros.jl") end
 @testset "recipe test" begin include("recipe_test.jl") end
 @testset "latexify tests" begin include("latexify_test.jl") end
 @testset "latexraw tests" begin include("latexraw_test.jl") end


### PR DESCRIPTION
Poor practice, but this PR contains two separate new features.

One is the exported function `render` which tries to render a LaTeXString using lualatex and open the result in an external viewer. Useful for rendering things when in the REPL.

The other is a macro `@latexify` which can be used to directly latexify one-liner Julia functions.
```julia
julia> @latexify f(x, y=2) = x^2 + y
$\mathrm{f}\left( x, y = 2 \right) = x^{2} + y$
```
This macro call will also define `f` as expected.

No documentation or test yet.