### PR TITLE
Use standard syntax for including files

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -51,19 +51,19 @@ include("numberformatters.jl")
 ### Add support for additional packages without adding them as dependencies.
 function __init__()
     @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" begin
-        include(joinpath("plugins", "ParameterizedFunctions.jl"))
+        include("plugins/ParameterizedFunctions.jl")
     end
     @require DiffEqBiological = "eb300fae-53e8-50a0-950c-e21f52c2b7e0" begin
-        include(joinpath("plugins", "DiffEqBiological.jl"))
+        include("plugins/DiffEqBiological.jl")
     end
     @require SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8" begin
-        include(joinpath("plugins", "SymEngine.jl"))
+        include("plugins/SymEngine.jl")
     end
     @require Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28" begin
-        include(joinpath("plugins", "Missings.jl"))
+        include("plugins/Missings.jl")
     end
     @require DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0" begin
-        include(joinpath("plugins", "DataFrames.jl"))
+        include("plugins/DataFrames.jl")
     end
 end
 


### PR DESCRIPTION
There's no reason to use `joinpath` here since this syntax is supported across different OSs, and it has the potential to cause problems with tools that try to statically understand `include`s.