### PR TITLE
WIP: first attempt at updating for Catalyst

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -53,7 +53,7 @@ function __init__()
     @require DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e" begin
         include("plugins/ParameterizedFunctions.jl")
     end
-    @require DiffEqBiological = "eb300fae-53e8-50a0-950c-e21f52c2b7e0" begin
+    @require ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78" begin
         include("plugins/DiffEqBiological.jl")
     end
     @require SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8" begin


### PR DESCRIPTION
So there is much more todo, and it might be better for someone else to handle it, but this is a first attempt at updating for the new ModelingToolkit-based DEBio (i.e. Catalyst). It still needs testing but I wanted feedback before putting more time into this. 

I think I've updated the `chemical_arrows` function to now handle ModelingToolkit `ReactionSystem`s, but obviously the interface needs work. Ideally this would be what gets called if one says `latexify(rs::ReactionSystem; kwargs...)`. I'm assuming we no longer need the ODE/SDE overloads since we can just call them on ModelingToolkit `ODESystem`s and `SDESystem`s we've converted the `ReactionSystem` too (though would this mean we can't get the bracket notation for concentrations?).

@korsbo comments / suggestions?