### PR TITLE
Support {cases} environments and logical operators

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -158,11 +158,11 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
         if length(args) == 3
             # Check if already parsed elseif as args[3]
             haselseif::Bool = occursin(Regex("\\$textif"), args[3])
-            otherwise::String = haselseif ? "" : "& \\text{otherwise}"
-            return """$begincases $(args[2]) & $textif $(args[1])\\\\
-                      $(args[3]) $otherwise $endcases"""
+            otherwise::String = haselseif ? "" : " & \\text{otherwise}"
+            return """$begincases$(args[2]) & $textif $(args[1])\\\\
+                      $(args[3])$otherwise$endcases"""
         elseif length(args) == 2
-            return "$begincases $(args[2]) & $textif $(args[1]) $endcases"
+            return "$begincases$(args[2]) & $textif $(args[1])$endcases"
         end
     end
 

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -74,10 +74,10 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
 
     # infix_operators = [:<, :>, Symbol("=="), :<=, :>=, :!=]
     comparison_operators = Dict(
-        :< => "\\lt",
-        :.< => "\\lt",
-        :> => "\\gt",
-        :.> => "\\gt",
+        :< => "<",
+        :.< => "<",
+        :> => ">",
+        :.> => ">",
         Symbol("==") => "=",
         Symbol(".==") => "=",
         :<= => "\\leq",

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -61,6 +61,8 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
         return "$(args[2])^{$(args[3])}"
     elseif (ex.head in (:(=), :function)) && length(args) == 2
         return "$(args[1]) = $(args[2])"
+    elseif op == :(!)
+        return "\\neg $(args[2])"
     end
 
     if ex.head == :.
@@ -158,6 +160,10 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
             return "$begincases $(args[2]) & $textif $(args[1]) $endcases"
         end
     end
+
+    ## Conditional operators converted to logical operators.
+    ex.head == :(&&) && length(args) == 2 && return "$(args[1]) \\wedge $(args[2])"
+    ex.head == :(||) && length(args) == 2 && return "$(args[1]) \\vee $(args[2])"
 
     ## if we have reached this far without a return, then error.
     error("Latexify.jl's latexoperation does not know what to do with one of the

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -109,17 +109,22 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     op == :abs && return "\\left\\|$(args[2])\\right\\|"
     op == :exp && return "e^{$(args[2])}"
 
+    ## Leave math italics for single-character operator names (e.g., f(x)).
+    opname = string(op)
+    if length(opname) > 1
+        opname = "\\mathrm{$opname}"
+    end
 
     if ex.head == :ref
         argstring = join(args[2:end], ", ")
-        return "\\mathrm{$op}\\left[$argstring\\right]"
+        return "$opname\\left[$argstring\\right]"
     end
 
     if ex.head == :call
         if args[2] isa String && occursin("=", args[2])
-            return "\\mathrm{$op}\\left( $(join(args[3:end], ", ")); $(args[2]) \\right)"
+            return "$opname\\left( $(join(args[3:end], ", ")); $(args[2]) \\right)"
         else
-            return "\\mathrm{$op}\\left( $(join(args[2:end], ", ")) \\right)"
+            return "$opname\\left( $(join(args[2:end], ", ")) \\right)"
         end
     end
 

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -40,14 +40,14 @@ array_test = [ex, str]
 @test latexraw(:(csch(x))) ==  "\\mathrm{csch}\\left( x \\right)"
 @test latexraw(:(acsch(x))) ==  "\\mathrm{arccsch}\\left( x \\right)"
 @test latexraw(:(x ± y)) == "x \\pm y"
-@test latexraw(:(f(x))) ==  "\\mathrm{f}\\left( x \\right)"
+@test latexraw(:(f(x))) ==  "f\\left( x \\right)"
 @test latexraw("x = 4*y") == "x = 4 \\cdot y"
 @test latexraw(:(sqrt(x))) == "\\sqrt{x}"
 @test latexraw(complex(1,-1)) == "1-1\\textit{i}"
 @test latexraw(1//2) == "\\frac{1}{2}"
 @test latexraw(Missing()) == "\\textrm{NA}"
-@test latexraw("x[2]") == raw"\mathrm{x}\left[2\right]"
-@test latexraw("x[2, 3]") == raw"\mathrm{x}\left[2, 3\right]"
+@test latexraw("x[2]") == raw"x\left[2\right]"
+@test latexraw("x[2, 3]") == raw"x\left[2, 3\right]"
 @test latexraw("α") == raw"\alpha"
 @test latexraw("α + 1") == raw"\alpha + 1"
 @test latexraw("α₁") == raw"\alpha_{1}"
@@ -80,7 +80,7 @@ end c_1 c_2
 
 
 @test latexraw(:(3 * (a .< b .<= c < d <= e > f <= g .<= h .< i == j .== k != l .!= m))) ==
-raw"3 \cdot \left( a \lt b \leq c \lt d \leq e \gt f \leq g \leq h \lt i = j = k \neq l \neq m \right)"
+raw"3 \cdot \left( a < b \leq c < d \leq e > f \leq g \leq h < i = j = k \neq l \neq m \right)"
 
 
 
@@ -135,7 +135,7 @@ test_functions = [:sinh, :alpha, :Theta, :cosc, :acoth, :acot, :asech, :lambda,
                   :acsch, :theta, :asec, :Sigma, :sin]
 
 
-@test latexify(["3*$(func)(x)^2/4 -1" for func = test_functions]) == 
+@test latexify(["3*$(func)(x)^2/4 -1" for func = test_functions]) ==
 raw"\begin{equation}
 \left[
 \begin{array}{c}
@@ -209,3 +209,43 @@ raw"\begin{equation}
 "
 
 
+## Test logical operators
+@test latexraw(:(x && y)) == "x \\wedge y"
+@test latexraw(:(x || y)) == "x \\vee y"
+@test latexraw(:(x || !y)) == "x \\vee \\neg y"
+
+
+## Test {cases} enviroment
+@test latexraw(:(R(p,e,d) = e ? 0 : log(p) - d)) ==
+raw"R\left( p, e, d \right) = \begin{cases}
+0 & \text{if } e\\
+\log\left( p \right) - d & \text{otherwise}
+\end{cases}"
+
+@test latexraw(:(R(p,e,d,t) = if (t && e); 0 elseif (t && !e); d else log(p) end)) ==
+raw"R\left( p, e, d, t \right) = \begin{cases}
+0 & \text{if } t \wedge e\\
+d & \text{if } t \wedge \neg e\\
+\log\left( p \right) & \text{otherwise}
+\end{cases}"
+
+@test latexraw(:(function reward(p,e,d,t)
+    if t && e
+        return 0
+    elseif t && !e
+        return -1d
+    elseif 2t && e
+        return -2d
+    elseif 3t && e
+        return -3d
+    else
+        return log(p)
+    end
+end)) ==
+raw"\mathrm{reward}\left( p, e, d, t \right) = \begin{cases}
+0 & \text{if } t \wedge e\\
+-1 \cdot d & \text{if } t \wedge \neg e\\
+-2 \cdot d & \text{if } 2 \cdot t \wedge e\\
+-3 \cdot d & \text{if } 3 \cdot t \wedge e\\
+\log\left( p \right) & \text{otherwise}
+\end{cases}"


### PR DESCRIPTION
Pardon four changes bundled into one PR. The main contribution is adding support to translate Julia conditional blocks (and ternary ifs) to LaTeX `cases` environments. See an example with stressing cases here:

- PDF: https://github.com/mossr/TeX.jl/blob/master/test/pdf/latexify_cases.pdf
- Code: https://github.com/mossr/TeX.jl/blob/master/test/test_latexify_cases.jl

The other minor contributions are:

1. Add support for logical operators: `\wedge` for `&&`, `\vee` for `||`, and `\neg` for `!`
2. Changed `\lt` and `\gt` to `<` and `>` (these commands were not defined using standard `amsmath`)
3. Skip applying `\mathrm` to function operator names when they're single characters (e.g., `f(x)` should be math-italicized and `loss(x)` should not)

By the way, great work with this package! It was super easy to extend it for my cases 😄 