### PR TITLE
Ensure application of latexraw on leaf nodes.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 environment:
   matrix:
   - julia_version: 0.7
-  - julia_version: 1.0
   - julia_version: 1.1
-  - julia_version: 1.2
+  - julia_version: 1.5
   - julia_version: nightly
 
 platform:

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -8,8 +8,7 @@ a parenthesis is needed.
 """
 function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     op = ex.args[1]
-    convertSubscript!(ex)
-    args = map(i -> i isa Number ? latexraw(i; kwargs...) : i, ex.args)
+    args = map(i -> !isa(i,  String) ? latexraw(i; kwargs...) : i, ex.args)
 
     # Remove math italics for variables (i.e. words) longer than 2 characters.
     args = map(i -> (i isa String && all(map(isletter, collect(i))) && length(i) > 2) ? "{\\rm $i}" : i, args)

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -8,7 +8,7 @@ a parenthesis is needed.
 """
 function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
     op = ex.args[1]
-    args = map(i -> !isa(i,  String) ? latexraw(i; kwargs...) : i, ex.args)
+    args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw(i; kwargs...) : i, ex.args)
 
     # Remove math italics for variables (i.e. words) longer than 2 characters.
     args = map(i -> (i isa String && all(map(isletter, collect(i))) && length(i) > 2) ? "{\\rm $i}" : i, args)

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -71,7 +71,7 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                 ex.args[i] = latexarray(ex.args[i]; kwargs...)
             end
         end
-        return latexoperation(ex, prevOp; kwargs...)
+        return latexoperation(ex, prevOp; convert_unicode=convert_unicode, kwargs...)
     end
     ex = deepcopy(inputex)
     str = recurseexp!(ex)
@@ -130,4 +130,4 @@ environment that is capable of displaying not-maths objects. Try for example
     end
 end
 
-# @require Missings latexraw(i::Missings.Missing) = "\\textrm{NA}"
+latexraw(i::Missing) = "\\textrm{NA}"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -9,8 +9,10 @@ l2 = @latexrun dummyfunc2(x; y=1, z=3) = x^2/y + z
 @test dummyfunc2(1.) == 4
 
 l3 = @latexify dummyfunc2(x::Number; y=1, z=3) = x^2/y + z
-@test l3 == raw"$\mathrm{dummyfunc2}\left( x::{\rm Number}; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+@test l3 == raw"$\mathrm{dummyfunc2}\left( x::Number; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+
 
 l4 = @latexify dummyfunc2(::Number; y=1, z=3) = x^2/y + z
-@test l4 == raw"$\mathrm{dummyfunc2}\left( ::{\rm Number}; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+@test l4 == raw"$\mathrm{dummyfunc2}\left( ::Number; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
+
 


### PR DESCRIPTION
This fixes an issue where `convertSubscript` was not always applied to
symbols in expressions.