### PR TITLE
Minor fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -44,6 +44,7 @@ function latexalign end
 function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false, rows=:all, kwargs...)
     eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
     arr = latexraw(arr; kwargs...)
+    separator isa String && (separator = fill(separator, size(arr)[1]))
 
     str = "\\begin{align$(starred ? "*" : "")}\n"
     if rows == :all
@@ -51,11 +52,12 @@ function latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=fals
     else 
         iterate_rows = rows
     end
+
     for i in iterate_rows
         if i != last(iterate_rows)
-            str *= join(arr[i,:], separator) * eol
+            str *= join(arr[i,:], separator[i]) * eol
         else
-            str *= join(arr[i,:], separator) * "\n"
+            str *= join(arr[i,:], separator[i]) * "\n"
         end
     end
     str *= "\\end{align$(starred ? "*" : "")}\n"

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -122,8 +122,14 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
         return "$opname\\left[$argstring\\right]"
     end
 
+    if ex.head == :macrocall && ex.args[1] == Symbol("@__dot__") 
+        return ex.args[3]
+    end
+
     if ex.head == :call
-        if args[2] isa String && occursin("=", args[2])
+        if length(args) == 1
+            return "$opname()"
+        elseif args[2] isa String && occursin("=", args[2])
             return "$opname\\left( $(join(args[3:end], ", ")); $(args[2]) \\right)"
         else
             return "$opname\\left( $(join(args[2:end], ", ")) \\right)"
@@ -174,7 +180,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, kwargs...)
 
     ## if we have reached this far without a return, then error.
     error("Latexify.jl's latexoperation does not know what to do with one of the
-          expressions provides ($ex).")
+          expressions provided ($ex).")
     return ""
 end
 

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -9,5 +9,13 @@ raw"\begin{align}
 \end{align}
 "
 
+@test latexify(((1.0, 2), (3, 4)); separator = [" =& ", " ∈& "], env = :align) == 
+raw"\begin{align}
+1.0 =& 3 \\
+2 ∈& 4
+\end{align}
+"
+
+
 
 # @test_throws MethodError latexify(rn; bad_kwarg="should error")

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -14,6 +14,10 @@ desired_output = "2 \\cdot x^{2} - \\frac{y}{c_{2}}"
 array_test = [ex, str]
 @test all(latexraw(array_test) .== desired_output)
 
+@test latexraw(:(@__dot__(x / y))) == raw"\frac{x}{y}"
+@test latexraw(:(@. x / y)) == raw"\frac{x}{y}"
+@test latexraw(:(eps())) == raw"\mathrm{eps}()"
+
 @test latexraw(:y_c_a) == "y_{c\\_a}"
 @test latexraw(1.0) == "1.0"
 @test latexraw(1.00) == "1.0"


### PR DESCRIPTION
- fix handling of `@__dot__` in an expression.
- fix handling of zero-argument function calls in expressions (like `eps()`)
- allow align `separator` to be an iterable with one entry per row of the align env.