### PR TITLE
Fix latexification of arrays of expressions inside expressions.

### DIFF
--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -66,7 +66,11 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                                   if x.args[1] isa Expr && x.args[1].head == :row
                                       eval(x.head)(map(y -> permutedims(y.args), x.args)...)
                                   else 
-                                      eval(x.head)( x.args...)
+                                      if x.head in [:hcat, :row]
+                                          hcat( x.args...)
+                                      elseif x.head in [:vcat, :vect]
+                                          vcat( x.args...)
+                                      end
                                   end
                                   ; kwargs...) 
                        : 

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -66,7 +66,7 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                                   if x.args[1] isa Expr && x.args[1].head == :row
                                       eval(x.head)(map(y -> permutedims(y.args), x.args)...)
                                   else 
-                                      if x.head in [:hcat, :row]
+                                      if x.head == :hcat
                                           hcat( x.args...)
                                       elseif x.head in [:vcat, :vect]
                                           vcat( x.args...)

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -59,7 +59,20 @@ function latexraw end
 
 
 function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
-    inputex = postwalk(x -> x isa Expr && x.head in [:hcat, :vcat, :vect] ? latexarray(eval(x); kwargs...) : x, inputex)
+    ## Pass all arrays or matrices in the expr to latexarray
+    inputex = postwalk(x -> x isa Expr && x.head in [:hcat, :vcat, :vect] ? 
+                       latexarray(
+                                  ## If it is a matrix
+                                  if x isa Expr && x.args[1].head == :row
+                                      eval(x.head)(map(y -> permutedims(y.args), x.args)...)
+                                  else 
+                                      eval(x.head)( x.args...)
+                                  end
+                                  ; kwargs...) 
+                       : 
+                       x, inputex)
+
+    recurseexp!(lstr::LaTeXString) = lstr.s
     function recurseexp!(ex)
         prevOp = Vector{Symbol}(undef, length(ex.args))
         fill!(prevOp, :none)

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -63,7 +63,7 @@ function latexraw(inputex::Expr; convert_unicode=true, kwargs...)
     inputex = postwalk(x -> x isa Expr && x.head in [:hcat, :vcat, :vect] ? 
                        latexarray(
                                   ## If it is a matrix
-                                  if x isa Expr && x.args[1].head == :row
+                                  if x.args[1] isa Expr && x.args[1].head == :row
                                       eval(x.head)(map(y -> permutedims(y.args), x.args)...)
                                   else 
                                       eval(x.head)( x.args...)

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -8,6 +8,31 @@ ex = :(2*x^2 - y/c_2)
 
 desired_output = "2 \\cdot x^{2} - \\frac{y}{c_{2}}"
 
+@test latexify(:(a = [x / y; 3; 4])) == 
+raw"$a = \left[
+\begin{array}{c}
+\frac{x}{y} \\
+3 \\
+4 \\
+\end{array}
+\right]$"
+
+@test latexify(:(a = [x / y 2 3 4])) == 
+raw"$a = \left[
+\begin{array}{cccc}
+\frac{x}{y} & 2 & 3 & 4 \\
+\end{array}
+\right]$"
+
+@test latexify(:(a = [x / y 2; 3 4])) == 
+raw"$a = \left[
+\begin{array}{cc}
+\frac{x}{y} & 2 \\
+3 & 4 \\
+\end{array}
+\right]$"
+
+
 @test latexraw(str) == latexraw(ex)
 @test latexraw(ex) == desired_output
 


### PR DESCRIPTION
Fix so that 
```julia
latexify(:(a = [x/y 1; 2 3]))
```
no longer errors but instead gives the expected

$a = \left[
\begin{array}{cc}
\frac{x}{y} & 1 \\\\
2 & 3 \\\\
\end{array}
\right]$
