### PR TITLE
Shift equation<-array<-raw for arrays

### DIFF
--- a/docs/src/tutorials/rendering_latex.md
+++ b/docs/src/tutorials/rendering_latex.md
@@ -9,4 +9,4 @@ display("text/latex", x)
 ```
 where `x` is a latex-formatted string.
 
-This requires `x` to specify a ``\LaTeX`` environment. `latexalign` and `latexarray` already does this, but if you want to render the result of `latexify` you must supply an environment (for example `"\$ $x \$"`).
+This requires `x` to specify a ``\LaTeX`` environment. `latexalign` and `latexequation` already does this, but if you want to render the result of `latexify` you must supply an environment (for example `"\$ $x \$"`).

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -11,7 +11,7 @@ export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
     reset_default, @latexrecipe, render, @latexify, @latexrun
 
 ## Allow some backwards compatibility until its time to deprecate.
-export latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
+export latexequation, latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
 
 export StyledNumberFormatter, FancyNumberFormatter
 

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -43,7 +43,7 @@ latexalign(args...; kwargs...) = latexify(args...; kwargs..., env=:align)
 
 function _latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false, rows=:all, aligned=false, kwargs...)
     eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
-    arr = latexraw(arr; kwargs...)
+    arr = latexraw.(arr; kwargs...)
     separator isa String && (separator = fill(separator, size(arr)[1]))
     str = ""
     if aligned

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -25,7 +25,7 @@ function _latexarray(arr::AbstractArray; adjustment::Symbol=:c, transpose=false,
     str = "\\left[\n"
     str *= "\\begin{array}{" * "$(adjustment)"^columns * "}\n"
 
-    arr = latexify.(arr; kwargs...,env=:raw)
+    arr = latexraw.(arr; kwargs...)
     for i=1:rows, j=1:columns
         str *= arr[i,j]
         j==columns ? (str *= eol) : (str *= " & ")

--- a/src/latexbracket.jl
+++ b/src/latexbracket.jl
@@ -6,5 +6,5 @@ function _latexbracket(x; kwargs...)
     return latexstr
 end
 
-_latexbracket(x::Union{AbstractArray, Tuple}; kwargs...) = [latexbracket(i; kwargs...) for i in x]
+_latexbracket(x::Union{AbstractArray, Tuple}; kwargs...) = [latexbracket.(x; kwargs...)...]
 _latexbracket(args...; kwargs...) = latexbracket(args; kwargs...)

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -24,7 +24,7 @@ const OUTPUTFUNCTIONS = Dict(
                              :tabular   => _latextabular,
                              :table     => _latextabular,
                              :raw       => _latexraw,
-                             :array     => (args...; kwargs...) -> _latexequation(_latexarray(args...; kwargs...); kwargs...),
+                             :array     => _latexarray,
                              :align     => _latexalign,
                              :aligned   => (args...; kwargs...) -> _latexbracket(_latexalign(args...; kwargs..., aligned=true, starred=false); kwargs...),
                              :eq        => _latexequation,
@@ -48,7 +48,7 @@ Use overloading to determine which latex environment to output.
 This determines the default behaviour of `latexify()` for different inputs.
 """
 get_latex_function(args...) = _latexinline
-get_latex_function(args::AbstractArray...) = (args...; kwargs...) -> _latexequation(_latexarray(args...; kwargs...); kwargs...)
+get_latex_function(args::AbstractArray...) = _latexequation
 get_latex_function(args::AbstractDict) = (args...; kwargs...) -> _latexequation(_latexarray(args...; kwargs...); kwargs...)
 get_latex_function(args::Tuple...) = (args...; kwargs...) -> _latexequation(_latexarray(args...; kwargs...); kwargs...)
 get_latex_function(arg::LaTeXString) = (arg; kwargs...) -> arg

--- a/src/latexinline.jl
+++ b/src/latexinline.jl
@@ -6,5 +6,6 @@ function _latexinline(x; kwargs...)
     return latexstr
 end
 
-_latexinline(x::Union{AbstractArray, Tuple}; kwargs...) = [ _latexinline(i; kwargs...) for i in x ]
+_latexinline(x::AbstractArray; kwargs...) = _latexinline.(x; kwargs...)
+_latexinline(x::Tuple; kwargs...) = [_latexinline.(x; kwargs...)...]
 _latexinline(args...; kwargs...) = _latexinline(args; kwargs...)

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -8,14 +8,14 @@ a parenthesis is needed.
 """
 function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:bracket, kwargs...)
     op = ex.args[1]
-    args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw(i; kwargs...) : i, ex.args)
+    args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw.(i; kwargs...) : i, ex.args)
 
     # Remove math italics for variables (i.e. words) longer than 2 characters.
     # args = map(i -> (i isa String && all(map(isletter, collect(i))) && length(i) > 2) ? "{\\rm $i}" : i, args)
 
     if ex.head == :latexifymerge
         if all(prevOp .== :none)
-            return Symbol(join(ex.args))
+            return join(args)
         else
             return "$(args[1])\\left( $(join(args[2:end])) \\right)"
         end

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -60,7 +60,7 @@ latexraw(args...; kwargs...) = latexify(args...; kwargs..., env=:raw)
 function _latexraw(inputex::Expr; convert_unicode=true, kwargs...)
     ## Pass all arrays or matrices in the expr to latexarray
     inputex = postwalk(x -> x isa Expr && x.head in [:hcat, :vcat, :vect, :typed_vcat, :typed_hcat] ?
-                       _latexarray(expr_to_array(x); kwargs...)
+                       latexarray(expr_to_array(x); kwargs...)
                        : x,
                        inputex)
 
@@ -73,7 +73,7 @@ function _latexraw(inputex::Expr; convert_unicode=true, kwargs...)
                 length(ex.args[i].args) > 1 && ex.args[i].args[1] isa Symbol && (prevOp[i] = ex.args[i].args[1])
                 ex.args[i] = recurseexp!(ex.args[i])
             elseif ex.args[i] isa AbstractArray
-                ex.args[i] = _latexarray(ex.args[i]; kwargs...)
+                ex.args[i] = latexraw(ex.args[i]; kwargs...)
             end
         end
         return latexoperation(ex, prevOp; convert_unicode=convert_unicode, kwargs...)
@@ -89,7 +89,7 @@ function _latexraw(args...; kwargs...)
     @assert length(args) > 1 "latexify does not support objects of type $(typeof(args[1]))."
     _latexraw(args; kwargs...)
 end
-_latexraw(arr::Union{AbstractArray, Tuple}; kwargs...) = [latexraw(i; kwargs...) for i in arr]
+_latexraw(arr::Union{AbstractArray, Tuple}; kwargs...) = _latexarray(arr; kwargs...)
 _latexraw(i::Nothing; kwargs...) = ""
 _latexraw(i::SubString; kwargs...) = latexraw(Meta.parse(i); kwargs...)
 _latexraw(i::SubString{LaTeXStrings.LaTeXString}; kwargs...) = i

--- a/src/latextabular.jl
+++ b/src/latextabular.jl
@@ -21,7 +21,7 @@ function _latextabular(arr::AbstractMatrix; latex::Bool=true, booktabs::Bool=fal
     end
 
     if latex
-        arr = latexinline(arr; kwargs...)
+        arr = latexinline.(arr; kwargs...)
     elseif haskey(kwargs, :fmt)
         formatter = kwargs[:fmt] isa String ? PrintfNumberFormatter(kwargs[:fmt]) : kwargs[:fmt]
         arr = map(x -> x isa Number ? formatter(x) : x, arr)

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -8,10 +8,10 @@ using Test
 
 @test latexify(:(x * y); env=:inline, cdot=true) == raw"$x \cdot y$"
 
-@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=false) == 
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=false) ==
 raw"$x \left( y + z \right) y \left( z + a \right) \left( z + b \right)$"
 
-@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=true) == 
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=true) ==
 raw"$x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)$"
 
 # raw
@@ -19,14 +19,14 @@ raw"$x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left
 
 @test latexify(:(x * y); env=:raw, cdot=true) == raw"x \cdot y"
 
-@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=false) == 
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=false) ==
 raw"x \left( y + z \right) y \left( z + a \right) \left( z + b \right)"
 
-@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=true) == 
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=true) ==
 raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)"
 
 # array
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, transpose=true, cdot=false) ==
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, cdot=false) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -36,7 +36,7 @@ x y & x \left( y + z \right) y \left( z + a \right) \left( z + b \right) \\
 \end{equation}
 "
 
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:array, transpose=true, cdot=true) == 
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, cdot=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -52,7 +52,7 @@ x \cdot y & x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdo
 # mdtable
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]
 
-@test latexify(arr; env=:mdtable, cdot=false) == 
+@test latexify(arr; env=:mdtable, cdot=false) ==
 Markdown.md"| $x \left( y - 1 \right)$ |
 | ------------------------:|
 |                    $1.0$ |
@@ -61,7 +61,7 @@ Markdown.md"| $x \left( y - 1 \right)$ |
 |                   $symb$ |
 "
 
-@test latexify(arr; env=:mdtable, cdot=true) == 
+@test latexify(arr; env=:mdtable, cdot=true) ==
 Markdown.md"| $x \cdot \left( y - 1 \right)$ |
 | ------------------------------:|
 |                          $1.0$ |

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -8,7 +8,7 @@ ex = :(2*x^2 - y/c_2)
 
 desired_output = "2 \\cdot x^{2} - \\frac{y}{c_{2}}"
 
-@test latexify(:(a = [x / y; 3; 4])) == 
+@test latexify(:(a = [x / y; 3; 4])) ==
 raw"$a = \left[
 \begin{array}{c}
 \frac{x}{y} \\
@@ -17,14 +17,14 @@ raw"$a = \left[
 \end{array}
 \right]$"
 
-@test latexify(:(a = [x / y 2 3 4])) == 
+@test latexify(:(a = [x / y 2 3 4])) ==
 raw"$a = \left[
 \begin{array}{cccc}
 \frac{x}{y} & 2 & 3 & 4 \\
 \end{array}
 \right]$"
 
-@test latexify(:(a = [x / y 2; 3 4])) == 
+@test latexify(:(a = [x / y 2; 3 4])) ==
 raw"$a = \left[
 \begin{array}{cc}
 \frac{x}{y} & 2 \\
@@ -40,7 +40,7 @@ raw"$a = \left[
 @test latexify(:(u[1, 2]); index = :subscript) == raw"$u_{1,2}$"
 
 array_test = [ex, str]
-@test all(latexraw(array_test) .== desired_output)
+@test all(latexraw.(array_test) .== desired_output)
 
 @test latexraw(:(@__dot__(x / y))) == raw"\frac{x}{y}"
 @test latexraw(:(@. x / y)) == raw"\frac{x}{y}"
@@ -137,7 +137,7 @@ raw"\begin{align}
 \end{align}
 "
 
-@test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:array, fmt="%.2e") ==
+@test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:equation, fmt="%.2e") ==
 raw"\begin{equation}
 \left[
 \begin{array}{ccc}

--- a/test/recipe_test.jl
+++ b/test/recipe_test.jl
@@ -22,7 +22,7 @@ struct MyVec
 end
 
 @latexrecipe function f(v::MyVec; reverse=false)
-    env --> :array
+    env --> :equation
     fmt := "%.2f"
     return reverse ? v.vec[end, -1, 1] : v.vec
 end
@@ -32,7 +32,7 @@ struct MyTup
 end
 
 @latexrecipe function f(v::MyTup; reverse=false)
-    env --> :array
+    env --> :equation
     fmt := "%.2f"
     return reverse ? my_reverse(v.tup) : v.tup
 end
@@ -46,7 +46,7 @@ end
     return t.tup1, t.tup2
 end
 
-struct MyFloat 
+struct MyFloat
     x::Float64
 end
 
@@ -71,7 +71,7 @@ t = MyModule.MyType([:A, :B, 3.], [1., 2, 3])
 t2 = MyModule.MyType([:X, :Y, :(x/y)], Number[1.23434534, 232423.42345, 12//33])
 
 vec = [MyModule.MyFloat(x) for x in 1:4]
-@test latexify(vec; transpose=true) == 
+@test latexify(vec; transpose=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cccc}
@@ -82,7 +82,7 @@ raw"\begin{equation}
 "
 
 double_vec = MyModule.MyDoubleVec([MyModule.MyFloat(x) for x in 1:4], [MyModule.MyFloat(x) for x in 8:11])
-@test latexify(double_vec) == 
+@test latexify(double_vec) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -97,7 +97,7 @@ raw"\begin{equation}
 
 
 
-@test latexify(t2, fmt="%.8f") == 
+@test latexify(t2, fmt="%.8f") ==
 raw"\begin{align}
 X =& 1.23 \\
 Y =& 232423.42 \\
@@ -105,7 +105,7 @@ Y =& 232423.42 \\
 \end{align}
 "
 
-@test latexify(t) == 
+@test latexify(t) ==
 raw"\begin{align}
 A =& 1.00 \\
 B =& 2.00 \\
@@ -113,7 +113,7 @@ B =& 2.00 \\
 \end{align}
 "
 
-@test latexify(t; reverse=true) == 
+@test latexify(t; reverse=true) ==
 raw"\begin{align}
 1.00 =& A \\
 2.00 =& B \\
@@ -121,7 +121,7 @@ raw"\begin{align}
 \end{align}
 "
 
-@test latexify(t; env=:array) == 
+@test latexify(t; env=:equation) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -133,7 +133,7 @@ B & 2.00 \\
 \end{equation}
 "
 
-@test latexify(t; env=:array, reverse=true) == 
+@test latexify(t; env=:equation, reverse=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -147,7 +147,7 @@ raw"\begin{equation}
 
 
 vec = MyModule.MyVec([1., 2.])
-@test latexify(vec, transpose=true) == 
+@test latexify(vec, transpose=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -159,7 +159,7 @@ raw"\begin{equation}
 
 tup = MyModule.MyTup((1., 2.))
 
-@test latexify(tup, transpose=true) == 
+@test latexify(tup, transpose=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -169,7 +169,7 @@ raw"\begin{equation}
 \end{equation}
 "
 
-@test latexify(tup, reverse=true, transpose=true) == 
+@test latexify(tup, reverse=true, transpose=true) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -182,7 +182,7 @@ raw"\begin{equation}
 
 
 tup2 = MyModule.MyDoubleTup((1., 3), (2., 4.))
-@test latexify(tup2) == 
+@test latexify(tup2) ==
 raw"\begin{equation}
 \left[
 \begin{array}{cc}


### PR DESCRIPTION
Right now, `latexarray(::Array)` puts an `equation` around an array, and there is a pattern that `latexraw(x::Arr) == [ latexraw(x[1]), latexraw(x[2]), ... ]` for some of the commands. I think it would make more sense to have `latexarray` *just* do the array, `latexraw(::Array)` call `_latexarray`, and use broadcasting (`latexraw.(arr)`) to latexify each item of `arr`. This makes it easier to dispatch on `Array` types in recipes. 

`latexify(::Array)` now infers that you want to use `_latexequation`, rather than `(...) -> _latexequation(_latexarray(...))`. Since `latexraw(::Array)` now does the brackets and everything, when `_latexequation()` calls `latexraw` it will successfully latexify the array.

Small changes in usage, see how the tests have changed.

Also included: The `Symbol` change from #144 