### PR TITLE
Avoid deprecated convert function

### DIFF
--- a/src/plugins/DataFrames.jl
+++ b/src/plugins/DataFrames.jl
@@ -11,19 +11,19 @@ get_md_function(args::DataFrames.DataFrame) = mdtable
 
 
 function mdtable(d::DataFrames.DataFrame; kwargs...)
-    body = convert(Matrix, d)
+    body = Matrix(d)
     head = propertynames(d)
     mdtable(body; head=head, kwargs...)
 end
 
 function _latextabular(d::DataFrames.DataFrame; kwargs...)
-    body = convert(Matrix, d)
+    body = Matrix(d)
     head = propertynames(d)
     _latextabular(body; head=head, kwargs...)
 end
 
 function _latexarray(d::DataFrames.DataFrame; kwargs...)
-    body = convert(Matrix, d)
+    body = Matrix(d)
     head = permutedims(propertynames(d))
     result = vcat(head, body)
     _latexarray(result; kwargs...)


### PR DESCRIPTION
In DataFrames 0.22.6, 
```
convert(Matrix, df)
```
was [deprecated](https://github.com/JuliaData/DataFrames.jl/blob/73ca8f190bffcba8cd78ef911d62562357be1cc8/NEWS.md#dataframes-v0226-release-notes) in favor of 
```
Matrix(df)
```
You can see that the warnings did occur for the most [recent CI run on Julia 1](https://github.com/korsbo/Latexify.jl/runs/2227953398). I noticed the warnings because I'm using `jldoctest` which will fail when warnings occur.