### PR TITLE
Don't double broadcast

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -6,9 +6,9 @@ This uses the information about the previous operations to decide if
 a parenthesis is needed.
 
 """
-function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:bracket, kwargs...)::String 
+function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:bracket, kwargs...)::String
     op = ex.args[1]
-    args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw.(i; kwargs...) : i, ex.args)
+    args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw(i; kwargs...) : i, ex.args)
 
     # Remove math italics for variables (i.e. words) longer than 2 characters.
     # args = map(i -> (i isa String && all(map(isletter, collect(i))) && length(i) > 2) ? "{\\rm $i}" : i, args)

--- a/test/recipe_test.jl
+++ b/test/recipe_test.jl
@@ -50,6 +50,11 @@ struct MyFloat
     x::Float64
 end
 
+@latexrecipe function f(m::MyFloat)
+    fmt --> "%.6e"
+    return m.x*m.x
+end
+
 @latexrecipe function f(vec::Vector{T}) where T <: MyFloat
     fmt --> "%.4e"
     return [myfloat.x for myfloat in vec]
@@ -69,6 +74,10 @@ end
 using .MyModule
 t = MyModule.MyType([:A, :B, 3.], [1., 2, 3])
 t2 = MyModule.MyType([:X, :Y, :(x/y)], Number[1.23434534, 232423.42345, 12//33])
+
+m = MyModule.MyFloat(3)
+@test latexify(m) == raw"$9.000000e+00$"
+@test latexify(:(2+$m)) == raw"$2 + 9.000000e+00$"
 
 vec = [MyModule.MyFloat(x) for x in 1:4]
 @test latexify(vec; transpose=true) == replace(


### PR DESCRIPTION
This reverts a change I made in #146. Kind of obscure difference, it seems most of the time `i` here is either a string or some kind of scalar anyway. I can't even formulate a test for this without pulling in a dependency for Unitful. But it seems to me that the intention is not to broadcast into `i`, and this doesn't break any tests so...

(If you're curious, for some reason there are types in Unitful that are broadcastable but don't have a `length` method, so `latexraw.(i)` errors out for them. I'm opening an issue for this over there too, but irrespective I think this is the intended behaviour here)