### PR TITLE
Fix broken align for "x = y".

### DIFF
--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -100,7 +100,7 @@ end
 Go through the elements, split at any = sign, pass on as a matrix.
 """
 function _latexalign(vec::AbstractVector; kwargs...)
-    lvec = latexraw(vec; kwargs...)
+    lvec = _latexraw.(vec; kwargs...)
     ## turn the array into a matrix
     lmat = reduce(hcat, split.(lvec, " = "))
     ## turn the matrix ito arrays of left-hand-side, right-hand-side.

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -30,3 +30,10 @@ b =& 2
 ", "\r\n"=>"\n")
 
 # @test_throws MethodError latexify(rn; bad_kwarg="should error")
+
+# Latexify.@generate_test latexify(["a=1"], env=:align)
+@test latexify(["a=1"], env = :align) == replace(
+raw"\begin{align}
+a =& 1
+\end{align}
+", "\r\n"=>"\n")


### PR DESCRIPTION
Closes #159 