### PR TITLE
Add support for macros in Exprs.

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -8,6 +8,7 @@ a parenthesis is needed.
 """
 function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:bracket, kwargs...)::String
     op = ex.args[1]
+    filter!(x -> !(x isa LineNumberNode), ex.args)
     args = map(i -> typeof(i) ∉ (String, LineNumberNode) ? latexraw(i; kwargs...) : i, ex.args)
 
     # Remove math italics for variables (i.e. words) longer than 2 characters.
@@ -140,6 +141,10 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:brack
 
     if ex.head == :macrocall && ex.args[1] == Symbol("@__dot__")
         return string(ex.args[end])
+    end
+
+    if ex.head == :macrocall 
+        ex.head = :call
     end
 
     if ex.head == :call

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -16,3 +16,5 @@ l4 = @latexify dummyfunc2(::Number; y=1, z=3) = x^2/y + z
 @test l4 == raw"$\mathrm{dummyfunc2}\left( ::Number; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
 
 
+@test latexify(:(@hi(x / y))) == replace(
+raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")


### PR DESCRIPTION
`latexify(:(@hi(x/y)))` now works and results in `"$\mathrm{@hi}\left( \frac{x}{y} \right)$"`