### PR TITLE
Allow `render` toggling with a kwarg.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -10,6 +10,11 @@ function latexify(args...; kwargs...)
 
     result = latex_function(args...; kwargs...)
 
+    should_render = get(kwargs, :render, false)
+    should_render isa Bool || throw(ArgumentError(
+        "The keyword argument `render` must be either `true` or `false`. Got $should_render"
+        ))
+    should_render && render(result)
     COPY_TO_CLIPBOARD && clipboard(result)
     AUTO_DISPLAY && display(result)
     return result


### PR DESCRIPTION
`latexify(:(x/y), render=true)` should now be similar to `render(latexify(:(x/y))` (except that it also returns the `LaTeXString`). 

This allows users to conveniently set `set_default(; render=true)` if they want. 