### PR TITLE
Fix spurious top-level recursion.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -1,10 +1,12 @@
 function latexify(args...; kwargs...)
+    kwargs = merge(default_kwargs, kwargs)
     result = process_latexify(args...; kwargs...)
 
     should_render = get(kwargs, :render, false)
     should_render isa Bool || throw(ArgumentError(
         "The keyword argument `render` must be either `true` or `false`. Got $should_render"
         ))
+
     should_render && render(result)
     COPY_TO_CLIPBOARD && clipboard(result)
     AUTO_DISPLAY && display(result)
@@ -13,7 +15,7 @@ end
 
 function process_latexify(args...; kwargs...)
     ## Let potential recipes transform the arguments.
-    args, kwargs = apply_recipe(args...; default_kwargs..., kwargs...)
+    args, kwargs = apply_recipe(args...; kwargs...)
 
     ## If the environment is unspecified, use auto inference.
     env = get(kwargs, :env, :auto)

--- a/src/latexinline.jl
+++ b/src/latexinline.jl
@@ -1,7 +1,7 @@
 latexinline(args...;kwargs...) = process_latexify(args...;kwargs...,env=:inline)
 
 function _latexinline(x; kwargs...)
-    latexstr = latexstring( latexify(x; kwargs...,env=:raw) )
+    latexstr = latexstring( process_latexify(x; kwargs...,env=:raw) )
     COPY_TO_CLIPBOARD && clipboard(latexstr)
     return latexstr
 end


### PR DESCRIPTION
Default kwargs are now affecting the top-level latexify call too. Previously, `set_default(; render=true)` did not work.