### PR TITLE
Update latexoperation.jl to correctly process "//" in expressions as fractions

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -22,7 +22,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; cdot=true, index=:brack
         end
     end
 
-    if op in [:/, :./]
+    if op in [:/, :./, ://, :.//]
         return "\\frac{$(args[2])}{$(args[3])}"
 
     elseif op in [:*, :.*]


### PR DESCRIPTION
1//2 processed as a rational number; however "1//2" in expressions processed as //(1,2). 
Effectively for latexify // in expressions should be equivalent to /.