### PR TITLE
link_from_docs_to_repo

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,8 @@
 # Latexify.jl
 
-Latexify.jl is a package which supplies functions for producing ``\LaTeX`` formatted strings from Julia objects. The package allows for latexification of a many different kinds of Julia object and it can output several different ``\LaTeX`` or Markdown environments.
+[Latexify.jl](https://github.com/korsbo/Latexify.jl) is a package which supplies functions for producing ``\LaTeX`` 
+formatted strings from Julia objects. The package allows for latexification of a many different kinds of Julia object
+and it can output several different ``\LaTeX`` or Markdown environments.
 
 A small teaser:
 


### PR DESCRIPTION
I added a link from the main page of the docs back to the repo. This can be very helpful but isn't included in Documenter.jl right now, see also https://discourse.julialang.org/t/link-back-to-main-repo-on-each-page-in-documenter-jl/57444.

By the way, thanks for this nice package!