### PR TITLE
Complex number formatting

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -36,7 +36,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
         str=""
         for i in 2:length(args)
             arg = args[i]
-            prevOp[i] in [:+, :-, :±]  && (arg = "\\left( $arg \\right)")
+            (prevOp[i] in [:+, :-, :±] || ex.args[i] isa Complex) && (arg = "\\left( $arg \\right)")
             str = string(str, arg)
             i != length(args) && (str *= cdot ? " \\cdot " : " ")
         end
@@ -57,12 +57,12 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
                 return " + " * string(args[2])[2:end]
             elseif prevOp[2] == :none && string(args[2])[1] == '+'
                 return " - " * string(args[2])[2:end]
-            elseif prevOp[2] in [:+, :-, :±]
+            elseif prevOp[2] in [:+, :-, :±] || (ex.args[2] isa Complex)
                 return " - \\left( $(args[2]) \\right)"
             end
             return " - $(args[2])"
         end
-        prevOp[3] in [:+, :-, :±] &&  (args[3] = "\\left( $(args[3]) \\right)")
+        (prevOp[3] in [:+, :-, :±] || ex.args[3] isa Complex) && (args[3] = "\\left( $(args[3]) \\right)")
 
         if prevOp[3] == :none && string(args[3])[1] == '-'
             return "$(args[2]) + " * string(args[3])[2:end]

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -94,7 +94,8 @@ array_test = [ex, str]
 @test latexraw(:Inf) == raw"\infty"
 @test latexraw("Inf") == raw"\infty"
 @test latexraw(-Inf) == raw"-\infty"
-
+@test latexraw(:($(3+4im)*a)) == raw"\left( 3+4\textit{i} \right) \cdot a"
+@test latexraw(:(a*$(3+4im))) == raw"a \cdot \left( 3+4\textit{i} \right)"
 
 @test latexify(:((-1) ^ 2)) == replace(
 raw"$\left( -1 \right)^{2}$", "\r\n"=>"\n")
@@ -121,6 +122,8 @@ raw"$\left( \frac{3}{2} \right)^{2}$", "\r\n"=>"\n")
 @test latexraw("1 - 2 - (- 3 - 4)") == raw"1 - 2 - \left(  - 3 - 4 \right)"
 @test latexraw("1 - 2 - (- 3 -(2) + 4)") == raw"1 - 2 - \left(  - 3 - 2 + 4 \right)"
 @test latexraw("1 - 2 - (- 3 -(2 - 8) + 4)") == raw"1 - 2 - \left(  - 3 - \left( 2 - 8 \right) + 4 \right)"
+@test latexraw(:(-$(3+5im))) == raw" - \left( 3+5\textit{i} \right)"
+@test latexraw(:($(3+4im)-$(3+5im))) == raw"3+4\textit{i} - \left( 3+5\textit{i} \right)"
 
 # @test_throws ErrorException latexify("x/y"; env=:raw, bad_kwarg="should error")
 


### PR DESCRIPTION
Addresses #192:
- Use parentheses around complex numbers in multiplication.
- Treat complex numbers correctly in negation and nested sums/differences.