### PR TITLE
Change MIME type `image/pdf` to `application/pdf`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -71,7 +71,7 @@ function best_displayable()
     for mime_type in priority_list
         displayable(mime_type) && return mime_type
     end
-    return MIME("image/pdf")
+    return MIME("application/pdf")
 end
 
 


### PR DESCRIPTION
I suppose this is a tiny bug fix:
The fall-back MIME type (if none of the priority MIME types are `displayable`) was set to `image/pdf` which does not seem to be a correct MIME type. Therefore just calling `render` did not work for me, whereas specifying `application/pdf` explicitly did the job. Thanks.