### PR TITLE
Add sum and prod

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -130,6 +130,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
     op in (:sqrt, :√) && return "\\sqrt{$(args[2])}"
     op == :∛ && return "\\sqrt[3]{$(args[2])}"
     op == :∜ && return "\\sqrt[4]{$(args[2])}"
+    op in (:sum, :prod) && return "\\$(op) $(args[2])"
 
     ## Leave math italics for single-character operator names (e.g., f(x)).
     opname = replace(string(op), '_'=>raw"\_")

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -103,6 +103,17 @@ array_test = [ex, str]
 @test latexraw(:($(3+4im)*a)) == raw"\left( 3+4\textit{i} \right) \cdot a"
 @test latexraw(:(a*$(3+4im))) == raw"a \cdot \left( 3+4\textit{i} \right)"
 
+@test latexraw(:(sum(x_n))) == raw"\sum x_{n}"
+@test latexraw(:(sum(x_n for n in _))) == raw"\sum_{n} x_{n}"
+@test latexraw(:(sum(x_n for n in :))) == raw"\sum_{n} x_{n}"
+@test latexraw(:(sum(x_n for n in N))) == raw"\sum_{n \in N} x_{n}"
+@test latexraw(:(sum(x_n for n in n_0:N))) == raw"\sum_{n = n_{0}}^{N} x_{n}"
+@test latexraw(:(prod(x_n))) == raw"\prod x_{n}"
+@test latexraw(:(prod(x_n for n in _))) == raw"\prod_{n} x_{n}"
+@test latexraw(:(prod(x_n for n in :))) == raw"\prod_{n} x_{n}"
+@test latexraw(:(prod(x_n for n in N))) == raw"\prod_{n \in N} x_{n}"
+@test latexraw(:(prod(x_n for n in n_0:N))) == raw"\prod_{n = n_{0}}^{N} x_{n}"
+
 @test latexify(:((-1) ^ 2)) == replace(
 raw"$\left( -1 \right)^{2}$", "\r\n"=>"\n")
 @test latexify(:($(1 + 2im) ^ 2)) == replace(
@@ -110,9 +121,8 @@ raw"$\left( 1+2\textit{i} \right)^{2}$", "\r\n"=>"\n")
 @test latexify(:($(3 // 2) ^ 2)) == replace(
 raw"$\left( \frac{3}{2} \right)^{2}$", "\r\n"=>"\n")
 
-
 ### Test broadcasting
-@test latexraw(:(sum.((a, b)))) == raw"\mathrm{sum}\left( a, b \right)"
+@test latexraw(:(fun.((a, b)))) == raw"\mathrm{fun}\left( a, b \right)"
 
 
 


### PR DESCRIPTION
This operation had to happen ahead of the recursion, but I think the result is pretty neat:

![test](https://user-images.githubusercontent.com/6677110/151822782-c58d8d29-b4b9-4130-8a2d-8da41c337ca8.png)

```julia
latexalign(fill(:(A), 4), [
                              :(prod(x_n)),
                              :(sum(x_n for n in :)),
                              :(prod(x_n for n in N)),
                              :(sum(x_n for n in n_0:N)),
                             ])
```