### PR TITLE
Rework macros

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -179,6 +179,16 @@ They can for example be useful for latexifying simple mathsy functions like
 lstr = @latexrun f(x; y=2) = x/y
 ```
 
+The arguments to the macro can be interpolated with `$` to use the actual
+value, instead of the representation:
+```julia
+julia> @latexify x = abs2(-3)
+L"$x = \mathrm{abs2}\left( -3 \right)$"
+
+julia> @latexify x = $(abs2(-3))
+L"$x = 9$"
+```
+
 ## External rendering
 While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone PDF using LuaLaTeX and opens that file in your default PDF viewer.
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,13 +1,18 @@
 macro latexrun(expr)
-    return quote
-        $(esc(expr))
-        latexify($(string(expr)))
-    end
+    return esc(
+        Expr(
+            :block,
+            postwalk(expr) do ex
+                if ex isa Expr && ex.head == :$
+                    return ex.args[1]
+                end
+                return ex
+            end,
+            :(latexify($(Meta.quot(expr)))),
+        )
+    )
 end
 
-
 macro latexify(expr)
-    return quote
-        latexify($(string(expr)))
-    end
+    return esc(:(latexify($(Meta.quot(expr)))))
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,7 +1,7 @@
 l = @latexify dummyfunc(x; y=1, z=3) = x^2/y + z
 @test l == raw"$\mathrm{dummyfunc}\left( x; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
 
-@test_throws UndefVarError dummyfunc(1.) 
+@test_throws UndefVarError dummyfunc(1.)
 
 l2 = @latexrun dummyfunc2(x; y=1, z=3) = x^2/y + z
 @test l2 == raw"$\mathrm{dummyfunc2}\left( x; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
@@ -15,6 +15,11 @@ l3 = @latexify dummyfunc2(x::Number; y=1, z=3) = x^2/y + z
 l4 = @latexify dummyfunc2(::Number; y=1, z=3) = x^2/y + z
 @test l4 == raw"$\mathrm{dummyfunc2}\left( ::Number; y = 1, z = 3 \right) = \frac{x^{2}}{y} + z$"
 
+l5 = @latexify x = abs2(-3)
+@test l5 == raw"$x = \mathrm{abs2}\left( -3 \right)$"
+
+l6 = @latexify x = $(abs2(-3))
+@test l6 == raw"$x = 9$"
 
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -21,5 +21,13 @@ l5 = @latexify x = abs2(-3)
 l6 = @latexify x = $(abs2(-3))
 @test l6 == raw"$x = 9$"
 
+l7 = @latexrun x = abs2(-3)
+@test l7 == raw"$x = \mathrm{abs2}\left( -3 \right)$"
+@test x == 9
+
+l8 = @latexrun x = $(abs2(-3))
+@test l8 == raw"$x = 9$"
+@test x == 9
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")


### PR DESCRIPTION
The macros (`@latexrun`, `@latexify`) were going via strings, which meant they ignored some of the latexify logic. It also meant you couldn't run them using an interpolated value (variable, function call, ...).

With this PR, the macros are operating directly on the input expressions (with some escaping logic). The star of the show is you can now do 

```julia
julia> using Latexify, Unitful, UnitfulLatexify
julia> @latexrun v = 3.5u"m/s" # This has not changed
L"$v = 3.5 \cdot \mathrm{@u\_str}\left( m/s \right)$"
julia> @latexrun v = $(3.5u"m/s") # would error before the PR
L"$v = 3.5\;\mathrm{m}\,\mathrm{s}^{-1}$"
```