### PR TITLE
Add @latexdefine macro

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -169,21 +169,34 @@ and to reset your changes, use
 reset_default()
 ```
 ## Macros
-Two macros are exported. 
+Three macros are exported. 
 
 - `@latexify` simply latexifies the expression that you provide to it, similar to `latexify(:(...))`.
 - `@latexrun` both executes and latexifies the given expression. 
+- `@latexdefine` executes the expression, and latexifies the expression together with the its value
 
 They can for example be useful for latexifying simple mathsy functions like
 ```julia
-lstr = @latexrun f(x; y=2) = x/y
+julia> lstr = @latexrun f(x; y=2) = x/y
+L"$f\left( x; y = 2 \right) = \frac{x}{y}$"
+
+julia> f(1)
+0.5
+```
+
+```julia
+julia> @latexdefine x = 1/2
+L"$x = \frac{1}{2} = 0.5
+
+julia> x
+0.5
 ```
 
 The arguments to the macro can be interpolated with `$` to use the actual
 value, instead of the representation:
 ```julia
 julia> @latexify x = abs2(-3)
-L"$x = \mathrm{abs2}\left( -3 \right)$"
+L"$x = \left|-3\right|^{2}$"
 
 julia> @latexify x = $(abs2(-3))
 L"$x = 9$"

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -9,7 +9,7 @@ using Printf
 using Formatting
 
 export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
-    reset_default, @latexrecipe, render, @latexify, @latexrun
+    reset_default, @latexrecipe, render, @latexify, @latexrun, @latexdefine
 
 ## Allow some backwards compatibility until its time to deprecate.
 export latexequation, latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
@@ -73,7 +73,7 @@ end
 """
     @append_latexify_test!(fname, expr)
 
-Generate a Latexify test and append it to the file `fname`. 
+Generate a Latexify test and append it to the file `fname`.
 
 The expression `expr` should return a string when evaluated.
 
@@ -83,7 +83,7 @@ Latexify.@append_latexify_test!("./tests/latexify_tests.jl", latexify(:(x/y)))
 ```
 
 The macro returns the output of the expression and can often be rendered
-for a visual check that the test itself is ok. 
+for a visual check that the test itself is ok.
 ```
 Latexify.@append_latexify_test!("./tests/latexify_tests.jl", latexify(:(x/y))) |> render
 ```
@@ -93,7 +93,7 @@ macro append_latexify_test!(fname, expr)
     return :(
     str = "@test $($(string(expr))) == replace(\nraw\"$($(esc(expr)))\", \"\\r\\n\"=>\"\\n\")\n\n";
     open($fname, "a") do f
-        write(f,str) 
+        write(f,str)
     end;
     $(esc(expr))
     )

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,3 +1,39 @@
+"""
+    @latexify expression
+
+Create `LaTeXString` representing `expression`.
+Variables and expressions can be interpolated with `\$`.
+
+# Examples
+```julia-repl
+julia> @latexify x^2 + 3/2
+L"\$x^{2} + \\frac{3}{2}\$"
+
+julia> @latexify x^2 + \$(3/2)
+L"\$x^{2} + 1.5\$"
+```
+
+See also [`latexify`](@ref), [`@latexrun`](@ref), [`@latexdefine`](@ref).
+"""
+macro latexify(expr)
+    return esc(:(latexify($(Meta.quot(expr)))))
+end
+
+"""
+    @latexrun expression
+
+Latexify and evaluate `expression`. Useful for expressions with side effects, like assignments.
+
+# Examples
+```julia-repl
+julia> @latexrun y = 3/2 + \$(3/2)
+L"\$y = \\frac{3}{2} + 1.5\$"
+
+julia> y
+3.0
+```
+See also [`@latexify`](@ref), [`@latexdefine`](@ref).
+"""
 macro latexrun(expr)
     return esc(
         Expr(
@@ -13,6 +49,35 @@ macro latexrun(expr)
     )
 end
 
-macro latexify(expr)
-    return esc(:(latexify($(Meta.quot(expr)))))
+"""
+    @latexdefine expression
+
+Latexify `expression`, followed by an equals sign and the return value of its evaluation.
+Any side effects of the expression, like assignments, are evaluated as well.
+
+# Examples
+```julia-repl
+julia> @latexdefine y = 3/2 + \$(3/2)
+L"\$y = \\frac{3}{2} + 1.5 = 3.0\$"
+
+julia> y
+3.0
+```
+See also [`@latexify`](@ref), [`@latexrun`](@ref).
+"""
+macro latexdefine(expr)
+    return esc(
+        :(latexify(
+            Expr(
+                 :(=),
+                $(Meta.quot(expr)),
+                $(postwalk(expr) do ex
+                    if ex isa Expr && ex.head == :$
+                        return ex.args[1]
+                    end
+                    return ex
+                end),
+            )
+        )),
+    )
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -29,5 +29,9 @@ l8 = @latexrun x = $(abs2(-3))
 @test l8 == raw"$x = 9$"
 @test x == 9
 
+l9 = @latexdefine x = abs2(-2)
+@test l9 == raw"$x = \left|-2\right|^{2} = 4"
+@test x == 4
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -33,5 +33,9 @@ l9 = @latexdefine x = abs2(-2)
 @test l9 == raw"$x = \left|-2\right|^{2} = 4$"
 @test x == 4
 
+l10 = @latexdefine x = $(abs2(-2))
+@test l10 == raw"$x = 4 = 4$"
+@test x == 4
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -30,7 +30,7 @@ l8 = @latexrun x = $(abs2(-3))
 @test x == 9
 
 l9 = @latexdefine x = abs2(-2)
-@test l9 == raw"$x = \left|-2\right|^{2} = 4"
+@test l9 == raw"$x = \left|-2\right|^{2} = 4$"
 @test x == 4
 
 @test latexify(:(@hi(x / y))) == replace(


### PR DESCRIPTION
Adds a third printing macro `@latexdefine`, which does both of the things that `@latexrun` does (prints and evaluates expression), but also adds an equals sign and the evaluated value of the expression. This is useful for things like a Pluto workflow, where you can then in a single line get a variable's (new) definition.

```julia
julia> x = 35;

julia> @latexdefine y = 2x
L"$y = 2 \cdot x = 70$"

julia> @latexdefine y
L"$y = 70$"
```

I'm not married to the name.