### PR TITLE
Macrokwargs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -209,6 +209,7 @@ L"\begin{equation}
 x = 0.5
 \end{equation}
 "
+```
 
 ## External rendering
 While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone PDF using LuaLaTeX and opens that file in your default PDF viewer.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -202,6 +202,14 @@ julia> @latexify x = $(abs2(-3))
 L"$x = 9$"
 ```
 
+Keyword arguments can be supplied after these macros:
+```julia
+julia> @latexdefine x env=:equation
+L"\begin{equation}
+x = 0.5
+\end{equation}
+"
+
 ## External rendering
 While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone PDF using LuaLaTeX and opens that file in your default PDF viewer.
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -3,6 +3,7 @@
 
 Create `LaTeXString` representing `expression`.
 Variables and expressions can be interpolated with `\$`.
+Keyword arguments can be supplied to `latexify` by appending to the argument.
 
 # Examples
 ```julia-repl
@@ -11,6 +12,9 @@ L"\$x^{2} + \\frac{3}{2}\$"
 
 julia> @latexify x^2 + \$(3/2)
 L"\$x^{2} + 1.5\$"
+
+julia> @latexify x^2 + 3/2 env=:raw
+L"x^{2} + \\frac{3}{2}"
 ```
 
 See also [`latexify`](@ref), [`@latexrun`](@ref), [`@latexdefine`](@ref).
@@ -61,8 +65,11 @@ Any side effects of the expression, like assignments, are evaluated as well.
 
 # Examples
 ```julia-repl
-julia> @latexdefine y = 3/2 + \$(3/2)
-L"\$y = \\frac{3}{2} + 1.5 = 3.0\$"
+julia> @latexdefine y = 3/2 + \$(3/2) env=:equation
+L"\\begin{equation}
+y = \\frac{3}{2} + 1.5 = 3.0
+\\end{equation}
+"
 
 julia> y
 3.0

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -69,13 +69,13 @@ julia> y
 ```
 See also [`@latexify`](@ref), [`@latexrun`](@ref).
 """
-macro latexdefine(expr, kwargs...) # Currently broken
+macro latexdefine(expr, kwargs...)
     return esc(
         Expr(
             :call,
             :latexify,
             Expr(:parameters, _extractparam.(kwargs)...),
-            Expr(:(=), Meta.quot(expr), _executable(expr)),
+            Expr(:call, :Expr, QuoteNode(:(=)), Meta.quot(expr), _executable(expr)),
         ),
     )
 end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -47,8 +47,12 @@ l13 = @latexdefine y = x env=:raw
 @test l13 == raw"y = x = 1"
 
 env = :raw
-l14 = @latexdefine y env
-@test l14 == raw"y = 1"
+if VERSION > v"1.5.0" # Use 1.5 syntax if available
+    l14 = @latexdefine y env
+    @test l14 == raw"y = 1"
+else
+    @test_throws LoadError @latexdefine y env
+end
 
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -37,5 +37,18 @@ l10 = @latexdefine x = $(abs2(-2))
 @test l10 == raw"$x = 4 = 4$"
 @test x == 4
 
+l11 = @latexify x = 1 env=:raw
+@test l11 == raw"x = 1"
+
+l12 = @latexrun x = 1 env=:raw
+@test l12 == raw"x = 1"
+
+l13 = @latexdefine y = x env=:raw
+@test l13 == raw"y = x = 1"
+
+env = :raw
+l14 = @latexdefine y env
+@test l14 == raw"y = 1"
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -46,13 +46,11 @@ l12 = @latexrun x = 1 env=:raw
 l13 = @latexdefine y = x env=:raw
 @test l13 == raw"y = x = 1"
 
+#= # Loading a file with this in it doesn't work on VERSION < v"1.5.0"
 env = :raw
-if VERSION > v"1.5.0" # Use 1.5 syntax if available
-    l14 = @latexdefine y env
-    @test l14 == raw"y = 1"
-else
-    @test_throws LoadError @latexdefine y env
-end
+l14 = @latexdefine y env
+@test l14 == raw"y = 1"
+=#
 
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")


### PR DESCRIPTION
Allow keyword arguments to be passed to the latexify macros:

```julia
julia> @latexify x = 3 env=:raw
L"x = 3"
```