### PR TITLE
Add  kwarg post

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '0.7' 
           - '1' # Leave this line unchanged. '1' will automatically expand to the latest stable 1.x release of Julia.
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Latexify"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 authors = ["Niklas Korsbo <niklas.korsbo@gmail.com>"]
 repo = "https://github.com/korsbo/Latexify.jl.git"
-version = "0.15.14"
+version = "0.15.15"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -211,6 +211,18 @@ x = 0.5
 "
 ```
 
+A special keyword `post` can be supplied to `@latexdefine`, which is a
+function that will be called on the final right hand sign before
+latexification. This is merely formatting and will not affect any assignments.
+
+```julia
+julia> @latexdefine x=π  post=round
+L"$x = \pi = 3.0$"
+
+julia> @latexdefine x
+L"$x = \pi$"
+```
+
 ## External rendering
 While LaTeXStrings already render nicely in many IDEs or in Jupyter, they do not render in the REPL. Therefore, we provide a function `render(str)` which generates a standalone PDF using LuaLaTeX and opens that file in your default PDF viewer.
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -56,5 +56,10 @@ l15 = @latexdefine y = x post=float
 @test l15 == raw"$y = x = 1.0$"
 @test y isa Integer
 
+post = x->round(x; sigdigits=3)
+l16 = @latexdefine y = π post
+@test l16 == raw"$y = \pi = 3.14$"
+@test y == π
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -46,11 +46,9 @@ l12 = @latexrun x = 1 env=:raw
 l13 = @latexdefine y = x env=:raw
 @test l13 == raw"y = x = 1"
 
-#= # Loading a file with this in it doesn't work on VERSION < v"1.5.0"
 env = :raw
 l14 = @latexdefine y env
 @test l14 == raw"y = 1"
-=#
 
 l15 = @latexdefine y = x post=float
 @test l15 == raw"$y = x = 1.0$"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -52,5 +52,9 @@ l14 = @latexdefine y env
 @test l14 == raw"y = 1"
 =#
 
+l15 = @latexdefine y = x post=float
+@test l15 == raw"$y = x = 1.0$"
+@test y isa Integer
+
 @test latexify(:(@hi(x / y))) == replace(
 raw"$\mathrm{@hi}\left( \frac{x}{y} \right)$", "\r\n"=>"\n")


### PR DESCRIPTION
Adds a `post` kwarg to `@latexdefine`, which gives you a bit more control of how the final rhs is formatted.

```julia
julia> @latexdefine x=3.75 post=x->round(x; sigdigits=2)
L"$x = 3.75 = 3.8$"

julia> @latexdefine x=1//2 post=float
L"$x = \frac{1}{2} = 0.5$"

julia> using Unitful, UnitfulLatexify; m = 5u"kg"; v = 10u"m/s";

julia> @latexdefine E = m*v^2/2 post=u"J"
L"$E = \frac{m \cdot v^{2}}{2} = 250.0\;\mathrm{J}$"
```

I'm mostly interested in this last one for physics material, but I think this is general enough it could be useful in different contexts as well. 