### PR TITLE
Support diacritics (accents, ...)

### DIFF
--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -1,3 +1,27 @@
+@doc doc"""
+    latexify(args...; kwargs...)
+
+Latexify a string, an expression, an array or other complex types.
+
+```julia-repl
+julia> latexify("x+y/(b-2)^2")
+L"$x + \frac{y}{\left( b - 2 \right)^{2}}$"
+
+julia> latexify(:(x/(y+x)^2))
+L"$\frac{x}{\left( y + x \right)^{2}}$"
+
+julia> latexify(["x/y" 3//7 2+3im; 1 :P_x :(gamma(3))])
+L"\begin{equation}
+\left[
+\begin{array}{ccc}
+\frac{x}{y} & \frac{3}{7} & 2+3\mathit{i} \\
+1 & P_{x} & \Gamma\left( 3 \right) \\
+\end{array}
+\right]
+\end{equation}
+"
+```
+"""
 function latexify(args...; kwargs...)
     kwargs = merge(default_kwargs, kwargs)
     result = process_latexify(args...; kwargs...)

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -157,7 +157,7 @@ function _latexraw(::Val{true}, i::String; kwargs...)
         error("""
 in Latexify.jl:
 You are trying to create latex-maths from a `String` that cannot be parsed as
-an expression.
+an expression: `$i`.
 
 `latexify` will, by default, try to parse any string inputs into expressions
 and this parsing has just failed.

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -106,7 +106,7 @@ end
 
 function _executable(expr)
     return postwalk(expr) do ex
-        if ex isa Expr && ex.head == :$
+        if Meta.isexpr(ex, :$)
             return ex.args[1]
         end
         return ex

--- a/src/unicode2latex.jl
+++ b/src/unicode2latex.jl
@@ -21,7 +21,6 @@ import Base.Unicode
 """
 function latex_diacritics(c::Char)
     c = lowercase(c)
-    @assert length(c) == 1
     out = []
     for p in (
         # en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes

--- a/src/unicode2latex.jl
+++ b/src/unicode2latex.jl
@@ -1,4 +1,60 @@
-const unicodedict = Dict{Char, String}(
+import Base.Unicode
+
+"""
+- generate latex escape codes for diacritics of the latin alphabet (see https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes)
+- `@upper_lower` is used to generate a subset of the following sequence (uppercase and lowercase characters):
+    - 'à' => "\\`{a}"  # grave
+    - 'á' => "\\'{a}"  # acute
+    - 'ä' => "\\"{a}"  # umlaut (trema, dieresis)
+    - 'a̋' => "\\H{a}"  # hungarian umlaut (double acute)
+    - 'ã' => "\\~{a}"  # tilde
+    - 'â' => "\\^{a}"  # circumflex
+    - 'a̧' => "\\c{a}"  # cedilla
+    - 'ą' => "\\k{a}"  # ogonek
+    - 'ā' => "\\={a}"  # macron (bar above)
+    - 'a̱' => "\\b{a}"  # bar under
+    - 'ȧ' => "\\.{a}"  # dot above
+    - 'ạ' => "\\d{a}"  # dot under
+    - 'å' => "\\r{a}"  # ring
+    - 'ă' => "\\u{a}"  # breve
+    - 'ǎ' => "\\v{a}"  # caron (háček)
+"""
+function latex_diacritics(c::Char)
+    c = lowercase(c)
+    @assert length(c) == 1
+    out = []
+    for p in (
+        # en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes
+        '`' => 0x300,  # latex \`{c} maps to 'c' * Char(0x300)
+        "'" => 0x301,
+        '^' => 0x302,
+        '~' => 0x303,
+        '=' => 0x304,
+        'u' => 0x306,
+        '.' => 0x307,
+        '"' => 0x308,
+        'r' => 0x30a,
+        'H' => 0x30b,
+        'v' => 0x30c,
+        'd' => 0x323,
+        'c' => 0x327,
+        'k' => 0x328,
+        'b' => 0x331,
+    )
+        latex_escape, mark = p.first, Char(p.second)
+        lower, upper = c * mark, uppercase(c) * mark
+        # e.g. ('y' * Char(0x30A) == "ẙ") != (Char(0x1e99) == 'ẙ')
+        for p in (lower => "\\textrm{\\$latex_escape{$c}}", upper => "\\textrm{\\$latex_escape{$(uppercase(c))}}")
+            push!(out, p)
+            if (alias = length(p.first) == 1 ? p.first : Unicode.normalize(p.first)) != p.first
+                push!(out, (length(alias) == 1 ? first(alias) : alias) => p.second)
+            end
+        end
+    end
+    out
+end
+
+const unicodedict = Dict{Union{Char,String}, String}(
     '𝑅' => raw"\mathit{R}",
     '▐' => raw"\blockrighthalf",
     '♥' => raw"\varheartsuit",
@@ -2450,26 +2506,39 @@ const unicodedict = Dict{Char, String}(
     'Χ' => raw"\Chi",
     '⤮' => raw"\neovsearrow",
     '•' => raw"\bullet",
-    )
+    (latex_diacritics.('a':'z')...)...,
+)
 
 function unicode2latex(str::String; safescripts=false)
     isascii(str) && return str
-    str_array = [get(unicodedict, char, char) for char in str]
-    str_length = length(str_array)
 
-    for (i, char) in enumerate(str)
-        if str_array[i] isa String
-            if i < str_length && str_array[i+1] isa Char && (isletter(str_array[i+1]) || isdigit(str_array[i+1]))
-                str_array[i] = "{$(str_array[i])}"
+    c_or_s = sizehint!(Union{Char,String}[], length(str))
+
+    it = Iterators.Stateful(str)
+    while !isempty(it)
+        c = popfirst!(it)
+        push!(
+            c_or_s,  # see en.wikipedia.org/wiki/Combining_character
+            if Unicode.category_code(something(peek(it), '0')) == Unicode.UTF8PROC_CATEGORY_MN
+                c * popfirst!(it)
+            else
+                c
+            end
+        )
+    end
+    str_array = map(k -> get(unicodedict, k, k), c_or_s)
+
+    it = Iterators.Stateful(str_array)
+    while !isempty(it)
+        if (x = popfirst!(it)) isa String
+            if (xx = peek(it)) isa Char && (isletter(xx) || isdigit(xx))
+                str_array[it.taken] = "{$x}"
             end
         end
     end
 
-    str = join(str_array)
-    str = merge_subscripts(str; safescripts=safescripts)
-    str = merge_superscripts(str; safescripts=safescripts)
-
-    return str
+    str = merge_subscripts(join(str_array); safescripts=safescripts)
+    return merge_superscripts(str; safescripts=safescripts)
 end
 
 """

--- a/src/unicode2latex.jl
+++ b/src/unicode2latex.jl
@@ -42,10 +42,11 @@ function latex_diacritics(c::Char)
     )
         latex_escape, mark = p.first, Char(p.second)
         lower, upper = c * mark, uppercase(c) * mark
-        # e.g. ('y' * Char(0x30A) == "ẙ") != (Char(0x1e99) == 'ẙ')
+        # e.g. ('y' * Char(0x30a) == "ẙ") != (Char(0x1e99) == 'ẙ'), although they look the same
         for p in (lower => "\\textrm{\\$latex_escape{$c}}", upper => "\\textrm{\\$latex_escape{$(uppercase(c))}}")
             push!(out, p)
-            if (alias = length(p.first) == 1 ? p.first : Unicode.normalize(p.first)) != p.first
+            alias = length(p.first) == 1 ? p.first : Unicode.normalize(p.first)
+            if alias != p.first
                 push!(out, (length(alias) == 1 ? first(alias) : alias) => p.second)
             end
         end

--- a/src/unicode2latex.jl
+++ b/src/unicode2latex.jl
@@ -1,8 +1,10 @@
 import Base.Unicode
 
 """
-- generate latex escape codes for diacritics of the latin alphabet (see https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes)
-- `@upper_lower` is used to generate a subset of the following sequence (uppercase and lowercase characters):
+    latex_diacritics(c::Char)
+
+- generate latex escape codes for diacritics of the latin alphabet (upper and lower case), see https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes
+- also generate a subset of the following sequence, when the single char normalization is available:
     - 'à' => "\\`{a}"  # grave
     - 'á' => "\\'{a}"  # acute
     - 'ä' => "\\"{a}"  # umlaut (trema, dieresis)
@@ -23,8 +25,7 @@ function latex_diacritics(c::Char)
     c = lowercase(c)
     out = []
     for p in (
-        # en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes
-        '`' => 0x300,  # latex \`{c} maps to 'c' * Char(0x300)
+        '`' => 0x300,  # latex sequence \`{c} maps to 'c' * Char(0x300) := "c̀"
         "'" => 0x301,
         '^' => 0x302,
         '~' => 0x303,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -250,11 +250,11 @@ end
 safereduce(f, args) = length(args) == 1 ? f(args[1]) : reduce(f, args)
 
 function expr_to_array(ex)
-    ex.head == :typed_vcat && (ex = Expr(:vcat, ex.args[2:end]...))
-    ex.head == :typed_hcat && (ex = Expr(:hcat, ex.args[2:end]...))
-    ex.head == :ref && (ex = Expr(:vect, ex.args[2:end]...))
+    ex.head === :typed_vcat && (ex = Expr(:vcat, ex.args[2:end]...))
+    ex.head === :typed_hcat && (ex = Expr(:hcat, ex.args[2:end]...))
+    ex.head === :ref && (ex = Expr(:vect, ex.args[2:end]...))
     ## If it is a matrix
-    if ex.args[1] isa Expr && ex.args[1].head == :row
+    if Meta.isexpr(ex.args[1], :row)
         return eval(ex.head)(map(y -> permutedims(y.args), ex.args)...)
     else
         if ex.head == :hcat

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -31,4 +31,4 @@ reset_default()
 @test latexify("x * y") == 
 raw"$x \cdot y$"
 
-
+@test latexify("Plots.jl") isa LaTeXString

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ using Test
 @testset "latextabular tests" begin include("latextabular_test.jl") end
 @testset "mdtable tests" begin include("mdtable_test.jl") end
 @testset "DataFrame Plugin" begin include("plugins/DataFrames.jl") end
-@testset "unocode2latex" begin include("unicode2latex.jl") end
+@testset "unicode2latex" begin include("unicode2latex.jl") end
 @testset "cdot test" begin include("cdot_test.jl") end
 @testset "numberformatters" begin include("numberformatters_test.jl") end
 @testset "utils test" begin include("utils_test.jl") end

--- a/test/unicode2latex.jl
+++ b/test/unicode2latex.jl
@@ -12,3 +12,27 @@ raw"\begin{equation}
 ", "\r\n"=>"\n")
 
 @test latexify("αaβ") == raw"${\alpha}a\beta$"
+
+@test latexify("αaβ").s == raw"${\alpha}a\beta$"
+
+@test latexify("ÀéÜ"; parse=false).s == raw"$\textrm{\`{A}}\textrm{\'{e}}\textrm{\\\"{U}}$"
+
+@test latexify("w̋Ṽî"; parse=false).s == raw"$\textrm{\H{w}}\textrm{\~{V}}\textrm{\^{i}}$"
+
+@test latexify("çĘf̄"; parse=false).s == raw"$\textrm{\c{c}}\textrm{\k{E}}\textrm{\={f}}$"
+
+@test latexify("ṞȯX̣"; parse=false).s == raw"$\textrm{\b{R}}\textrm{\.{o}}\textrm{\d{X}}$"
+
+@test latexify("ẙĞž"; parse=false).s == raw"$\textrm{\r{y}}\textrm{\u{G}}\textrm{\v{z}}$"
+
+s = 'y' * Char(0x30a) * 'x' * Char(0x302) * 'a' * Char(0x331)
+@test latexify(s; parse=false).s == raw"$\textrm{\r{y}}\textrm{\^{x}}\textrm{\b{a}}$"
+
+s = 'Y' * Char(0x30a) * 'X' * Char(0x302) * 'A' * Char(0x331)
+@test latexify(s; parse=false).s == raw"$\textrm{\r{Y}}\textrm{\^{X}}\textrm{\b{A}}$"
+
+s = 'i' * Char(0x308) * 'z' * Char(0x304) * 'e' * Char(0x306)
+@test latexify(s; parse=false).s == raw"$\textrm{\\\"{i}}\textrm{\={z}}\textrm{\u{e}}$"
+
+s = 'I' * Char(0x308) * 'Z' * Char(0x304) * 'E' * Char(0x306)
+@test latexify(s; parse=false).s == raw"$\textrm{\\\"{I}}\textrm{\={Z}}\textrm{\u{E}}$"


### PR DESCRIPTION
- handle diacritics in a consistent manner, using escape sequences from https://en.wikibooks.org/wiki/LaTeX/Special_Characters#Escaped_codes.

```julia
julia> using Latexify
julia> latexify("éçà")
L"$\textrm{\'{e}}\textrm{\c{c}}\textrm{\`{a}}$"
```
- support `QuoteNode` in `latexraw` (e.g. when parsing `"Plots.jl"` as expr, corner case);
- add `latexify` docstring for `help?> latexify`;
- add failing expr error message when parsing fails;
- added a `parse` keyword to `_latexraw`, since `Meta.parse` can fail (especially parsing string containing diacritric markers - strings are normalized), and dispatch on `Val{true/false}` to `Meta.parse` or not.

Fix https://github.com/korsbo/Latexify.jl/issues/182.
Goes with https://github.com/JuliaPlots/Plots.jl/pull/4262.
