### PR TITLE
`render`: silent `dvipng` warnings

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -198,7 +198,7 @@ function render(s::LaTeXString, ::MIME"image/png";
     )
     render(s, MIME("application/x-dvi"); debug=debug, name=name, command=command, open=false, documentclass=documentclass, packages=packages)
 
-    cmd = `dvipng -bg Transparent -D $(dpi) -T tight -o $(name).png $(name).dvi`
+    cmd = `dvipng $(debug ? "" : "-q") -bg Transparent -D $(dpi) -T tight -o $(name).png $(name).dvi`
     debug || (cmd = pipeline(cmd, devnull))
     run(cmd)
 


### PR DESCRIPTION
Silent warnings on non debug output (like these ones):

```bash
[1dvipng warning: font [/usr/local/texlive/2022/texmf-dist/fonts/opentype/public/lm/lmroman12-regular.otf] at 480 dpi not found, characters will be left blank dvipng warning: unable to draw glyph 85, skipping dvipng warning: unable to draw glyph 82, skipping dvipng warning: unable to draw glyph 86, skipping dvipng warning: font [/usr/local/texlive/2022/texmf-dist/fonts/opentype/public/lm/lmroman12-regular.otf] at 480 dpi not found, characters will be left blank dvipng warning: unable to draw glyph 85, skipping dvipng warning: unable to draw glyph 82, skipping dvipng warning: unable to draw glyph 86, skipping 
```