### PR TITLE
Print benchmark results in log

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,3 +22,6 @@ jobs:
         run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Print results
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'
+


### PR DESCRIPTION
There's a permissions issue in getting benchmarks posted as a comment on PRs. This way, you can also check the benchmark results in the CI log.