### PR TITLE
Support for anonymous functions

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -206,6 +206,9 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
     ex.head == :(&&) && length(args) == 2 && return "$(args[1]) \\wedge $(args[2])"
     ex.head == :(||) && length(args) == 2 && return "$(args[1]) \\vee $(args[2])"
 
+    ## Anonymous function definition
+    ex.head == :(->) && length(args) == 2 && return "$(args[1]) \\mapsto $(args[2])"
+
 
 
     ## if we have reached this far without a return, then error.

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -313,6 +313,9 @@ raw"\begin{equation}
 @test latexraw(:(x || y)) == "x \\vee y"
 @test latexraw(:(x || !y)) == "x \\vee \\neg y"
 
+## Test anonymous function
+@test latexraw(:(x -> x^2)) == "x \\mapsto x^{2}"
+@test latexraw(:(f(p) = x -> p*x)) == "f\\left( p \\right) = x \\mapsto p \\cdot x"
 
 ## Test {cases} enviroment
 @test latexraw(:(R(p,e,d) = e ? 0 : log(p) - d)) == replace(


### PR DESCRIPTION
# Example
```julia
@latexify  x-> x^p
```
becomes

```julia
L"$x \mapsto x^{2}$"
```
