### PR TITLE
fix extension on Latexify 0.15

### DIFF
--- a/ext/ParameterizedFunctionsExt.jl
+++ b/ext/ParameterizedFunctionsExt.jl
@@ -1,7 +1,7 @@
 module ParameterizedFunctionsExt
 
 using Latexify
-isdefined(Base, :get_extension) ? (using ParameterizedFunctions) : (using ..ParameterizedFunctions)
+isdefined(Base, :get_extension) ? (using DiffEqBase) : (using ..DiffEqBase)
 
 
 ##################################################


### PR DESCRIPTION
This needs to be backported and released to 0.15 to avoid the breakage that the change to extensions introduced.