### PR TITLE
Update latexoperation.jl

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -80,7 +80,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
             str = get(functions, prevOp[2], "\\$(prevOp[2])")
             return replace(args[2], str => "$(str)^{$(args[3])}")
         end
-        if (prevOp[2] != :none) || (ex.args[2] isa Real && sign(ex.args[2]) == -1) || (ex.args[2] isa Complex && !iszero(ex.args[2].re)) || (ex.args[2] isa Rational)
+        if (prevOp[2] != :none) || (ex.args[2] isa Real && sign(ex.args[2]) == -1) || (ex.args[2] isa Complex && !iszero(ex.args[2].re)) || (ex.args[2] isa Rational) || !(ex.args[2] isa Real || ex.args[2] isa Symbol)
             args[2]="\\left( $(args[2]) \\right)"
         end
         return "$(args[2])^{$(args[3])}"


### PR DESCRIPTION
When interpolating Unitful types under an exponent, the latexoperation function should wrap ex.args[2] in parenthesis to properly display equation.

```Julia
julia> using Unitful, UnitfulLatexify, Latexify
julia> x = 2u"inch"
julia> y = 2u"inch"
julia> @latexdefine z = $x^2 + $y^2
L"$z = 2\;\mathrm{inch}^{2} + 2\;\mathrm{inch}^{2} = 8\;\mathrm{inch}^{2}$"
```
![298393262-bf7c74aa-9f3d-4e6f-83ee-83c5842ae1aa](https://github.com/korsbo/Latexify.jl/assets/143426779/fa745058-393b-480b-91e3-aa58469bfec9)

You can see from the image above that it should look more like: z = (2 inch)^2 + (2 inch)^2 = 8 inch^2

This pull request fixes that issue. It checks whether the ex.args[2] is Real or is a Symbol, and if it isn't one of those, it wraps the ex.args[2] in parenthesis. I realize this may be too broad of a criteria. I didn't want to add any dependencies, but hopefully this pull request opens discussion on how best to fix this. Thanks!