### PR TITLE
Disallow tensors

### DIFF
--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -18,6 +18,7 @@ function _latexarray(
         arr::AbstractArray; adjustment=:c, transpose=false,
         double_linebreak=false, starred=false, arraystyle=:square, kwargs...
     )
+    ndims(arr) > 2 && error("Cannot latexify n-dimensional tensors with n>2")
     transpose && (arr = permutedims(arr))
     rows, columns = axes(arr, 1), axes(arr, 2)
 

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -223,4 +223,6 @@ raw"$x = \left[
 \end{array}
 \right]$", "\r\n"=>"\n")
 
+tensor = [1;2;3;;4;5;6;;;7;8;9;;10;11;12]
+@test_throws "Cannot latexify n-dimensional tensors with n>2" latexify(tensor)
 

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -223,6 +223,6 @@ raw"$x = \left[
 \end{array}
 \right]$", "\r\n"=>"\n")
 
-tensor = [1;2;3;;4;5;6;;;7;8;9;;10;11;12]
-@test_throws "Cannot latexify n-dimensional tensors with n>2" latexify(tensor)
+tensor = rand(3,3,3)
+@test_throws ErrorException("Cannot latexify n-dimensional tensors with n>2") latexify(tensor)
 


### PR DESCRIPTION
Solves #284 

Higher-dimensional tensors cannot be simply printed, so this PR throws an error. A bit more informative than the indexing error it would have caused before.