### PR TITLE
Allow recipes to set previous operation

### DIFF
--- a/docs/src/tutorials/recipes.md
+++ b/docs/src/tutorials/recipes.md
@@ -79,3 +79,31 @@ The use of `@latexrecipe` to redefine how an already supported type should be in
 
 
 If a recipe is defined within a module, everything should just work without the need to export anything. 
+
+The special keyword argument `operation` lets you specify that a type corresponds to a specific arithmetic operation.
+For instance, if we define a type 
+```julia
+struct MyDifference
+x
+y
+end
+```
+that is meant to represent the operation `x - y`, we might want to create the recipe
+
+```julia
+@latexrecipe function f(m::MyDifference)
+    return :($(m.y) - $(m.x))
+end
+```
+so that the result of `latexify(MyDifference(2,3))` is ``3 - 2``.
+But right now, `latexify` does not know that this represents an operation, so for instance
+`@latexify $(MyDifference(2,3))*4` gives ``3 - 2 \cdot 4``, which is incorrect.
+The way around this is to edit the recipe:
+```julia
+@latexrecipe function f(m::MyDifference)
+    operation := :-
+    return :($(m.y) - $(m.x))
+end
+```
+Now `latexify` knows that `MyDifference` represents a subtraction, and parenthesis rules kick in:
+`@latexify $(MyDifference(2,3))*4` gives ``\left( 3 - 2 \right) \cdot 4``.

--- a/src/latexraw.jl
+++ b/src/latexraw.jl
@@ -88,8 +88,8 @@ function _latexraw(inputex::Expr; convert_unicode=true, kwargs...)
             end
         else
             for i in 1:length(ex.args)
+                prevOp[i] = _getoperation(ex.args[i])
                 if isa(ex.args[i], Expr)
-                    length(ex.args[i].args) > 1 && ex.args[i].args[1] isa Symbol && (prevOp[i] = ex.args[i].args[1])
                     ex.args[i] = recurseexp!(ex.args[i])
                 elseif ex.args[i] isa AbstractArray
                     ex.args[i] = latexraw(ex.args[i]; kwargs...)
@@ -175,3 +175,16 @@ environment that is capable of displaying not-maths objects. Try for example
 end
 
 _latexraw(i::Missing; kwargs...) = "\\textrm{NA}"
+
+"""
+    _getoperation(x)
+
+Check if `x` represents something that could affect the vector of previous operations.
+`:none` by default, recipes can use `operation-->:something` to hack this.
+"""
+function _getoperation(ex::Expr)
+    length(ex.args) > 1 && ex.args[1] isa Symbol && return ex.args[1]
+    return :none
+end
+_getoperation(x) = :none
+

--- a/test/recipe_test.jl
+++ b/test/recipe_test.jl
@@ -69,6 +69,15 @@ end
     return [myfloat.x for myfloat in vec.vec1], [myfloat.x for myfloat in vec.vec2]
 end
 
+struct MySum
+    x
+    y
+end
+@latexrecipe function f(s::MySum)
+    operation --> :+
+    return :($(s.x) + $(s.y))
+end
+
 end
 
 using .MyModule
@@ -202,4 +211,7 @@ raw"\begin{equation}
 \end{equation}
 ", "\r\n"=>"\n")
 
+sum1 = MyModule.MySum(3, 4)
+@test latexify(:(2 + $(sum1)^2)) == raw"$2 + \left( 3 + 4 \right)^{2}$"
+@test latexify(:(2 - $(sum1))) == raw"$2 - \left( 3 + 4 \right)$"
 


### PR DESCRIPTION
Previously, recipes had no way of affecting the previous operation. With this (somewhat ugly) change, a type that fundamentally represents for instance a multiplication or sum can tell latexify, so that things like parentheses work out right.

Part of fixing #280 

## TODO
* [x] Documentation
* [ ] Maybe more tests