### PR TITLE
Run mdtable and mdtext through latexify

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -49,30 +49,7 @@ keyword_arguments = [
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
     ]
 
-#= @latexrecipe function f(list::Array{KeywordArgument}; types=true) =#
-#=     isempty(list) && return nothing =#
-#=     sort!(list, by=x->x.kw) =#
-#=     keys = ["`:$(x.kw)`" for x in list] =#
-#=     # values = [join(["$i" for i in x.values], ", ") for x in list] =#
-#=     applicable_types = [join(["`$i`" for i in x.types], ", ") for x in list] =#
-#=     values = [x.values for x in list] =#
-#=     defaults = [x.default for x in list] =#
-#=     descriptions = [x.description for x in list] =#
-
-#=     latex --> false =#
-#=     env := :mdtable =#
-
-#=     if any(x->x.types != [:Any], list) && types =#
-#=         head --> ["Keyword", "Values", "Default", "Applicable types", "Description"] =#
-#=         return hcat(keys, values, defaults, applicable_types, descriptions) =#
-#=     else =#
-#=         head --> ["Keyword", "Values", "Default", "Description"] =#
-#=         return hcat(keys, values, defaults, descriptions) =#
-#=     end =#
-#= end =#
-
-import Latexify: mdtable
-function mdtable(list::Array{KeywordArgument}; types=true, kwargs...)
+@latexrecipe function f(list::Array{KeywordArgument}; types=true)
     isempty(list) && return nothing
     sort!(list, by=x->x.kw)
     keys = ["`:$(x.kw)`" for x in list]
@@ -81,9 +58,15 @@ function mdtable(list::Array{KeywordArgument}; types=true, kwargs...)
     values = [x.values for x in list]
     defaults = [x.default for x in list]
     descriptions = [x.description for x in list]
+
+    latex --> false
+    env := :mdtable
+
     if any(x->x.types != [:Any], list) && types
-        mdtable(hcat(keys, values, defaults, applicable_types, descriptions), head=["Keyword", "Values", "Default", "Applicable types", "Description"], latex=false)
+        head --> ["Keyword", "Values", "Default", "Applicable types", "Description"]
+        return hcat(keys, values, defaults, applicable_types, descriptions)
     else
-        mdtable(hcat(keys, values, defaults, descriptions), head=["Keyword", "Values", "Default", "Description"], latex=false)
+        head --> ["Keyword", "Values", "Default", "Description"]
+        return hcat(keys, values, defaults, descriptions)
     end
 end

--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -64,8 +64,8 @@ const OUTPUTFUNCTIONS = Dict(
                              :eq        => _latexequation,
                              :equation  => _latexequation,
                              :bracket   => _latexbracket,
-                             :mdtable   => mdtable,
-                             :mdtext    => mdtext,
+                             :mdtable   => _mdtable,
+                             :mdtext    => _mdtext,
                             )
 function infer_output(env, args...)
     env === :auto && return get_latex_function(args...)

--- a/src/mdtable.jl
+++ b/src/mdtable.jl
@@ -53,9 +53,9 @@ julia> mdtable(M; head=latexinline(head))
 | $\frac{x}{y}$ | $\frac{1}{2}$ |
 |       $p_{m}$ |       $e^{2}$ |
 """
-function mdtable end
+mdtable(args...; kwargs...) = latexify(args...; kwargs..., env=:mdtable)
 
-function mdtable(M::AbstractMatrix; latex::Bool=true, escape_underscores=false, head=[], side=[], transpose=false, adjustment=nothing, kwargs...)
+function _mdtable(M::AbstractMatrix; latex::Bool=true, escape_underscores=false, head=[], side=[], transpose=false, adjustment=nothing, kwargs...)
     transpose && (M = permutedims(M, [2,1]))
     if latex
         M = _latexinline.(M; kwargs...)
@@ -92,10 +92,10 @@ function mdtable(M::AbstractMatrix; latex::Bool=true, escape_underscores=false, 
     return t
 end
 
-mdtable(v::AbstractArray; kwargs...) = mdtable(reshape(v, (length(v), 1)); kwargs...)
-mdtable(v::AbstractArray...; kwargs...) = mdtable(safereduce(hcat, v); kwargs...)
-mdtable(d::AbstractDict; kwargs...) = mdtable(collect(keys(d)), collect(values(d)); kwargs...)
-mdtable(arg::Tuple; kwargs...) = mdtable(safereduce(hcat, [collect(i) for i in arg]); kwargs...)
+_mdtable(v::AbstractArray; kwargs...) = _mdtable(reshape(v, (length(v), 1)); kwargs...)
+_mdtable(v::AbstractArray...; kwargs...) = _mdtable(safereduce(hcat, v); kwargs...)
+_mdtable(d::AbstractDict; kwargs...) = _mdtable(collect(keys(d)), collect(values(d)); kwargs...)
+_mdtable(arg::Tuple; kwargs...) = _mdtable(safereduce(hcat, [collect(i) for i in arg]); kwargs...)
 
 get_header_rule(::Nothing) = "-------"
 function get_header_rule(adjustment::Symbol)

--- a/src/mdtext.jl
+++ b/src/mdtext.jl
@@ -1,5 +1,6 @@
+mdtext(args...; kwargs...) = latexify(args...; kwargs..., env=:mdtext)
 
-function mdtext(s::String; escape_underscores = false, kwargs...)
+function _mdtext(s::String; escape_underscores = false, kwargs...)
     escape_underscores && (s = replace(s, "_"=>"\\_"))
     m = Markdown.parse(s)
     return m

--- a/test/plugins/DataFrames_test.jl
+++ b/test/plugins/DataFrames_test.jl
@@ -4,6 +4,13 @@ using LaTeXStrings
 
 df = DataFrame(A = 'x':'z', B = ["α/β", 1//2, 8])
 
+@test mdtable(df) ==
+Markdown.md"|   A |                      B |
+| ---:| ----------------------:|
+| $x$ | $\frac{\alpha}{\beta}$ |
+| $y$ |          $\frac{1}{2}$ |
+| $z$ |                    $8$ |
+"
 
 @test latexify(df, latex=true) ==
 Markdown.md"|   A |                      B |


### PR DESCRIPTION
`mdtable` and `mdtext` were not using the recipe system (https://github.com/korsbo/Latexify.jl/pull/263#issuecomment-2215507951). 
Now they are. This is a direct parallel to how all other environments work.