### PR TITLE
Dots, hats, tildes and bars

### DIFF
--- a/test/unicode2latex.jl
+++ b/test/unicode2latex.jl
@@ -16,28 +16,30 @@ raw"\begin{equation}
 
 @test latexify("ÀéÜ"; parse=false).s == raw"$\textnormal{\`{A}}\textnormal{\'{e}}\textnormal{\\\"{U}}$"
 
-@test latexify("w̋Ṽî"; parse=false).s == raw"$\textnormal{\H{w}}\textnormal{\~{V}}\textnormal{\^{i}}$"
+@test latexify("w̋Ṽî"; parse=false).s == raw"$\textnormal{\H{w}}\tilde{V}\hat{i}$"
 
-@test latexify("çĘf̄"; parse=false).s == raw"$\textnormal{\c{c}}\textnormal{\k{E}}\textnormal{\={f}}$"
+@test latexify("çĘf̄"; parse=false).s == raw"$\textnormal{\c{c}}\textnormal{\k{E}}\bar{f}$"
 
-@test latexify("ṞȯX̣"; parse=false).s == raw"$\textnormal{\b{R}}\textnormal{\.{o}}\textnormal{\d{X}}$"
+@test latexify("ṞȯX̣"; parse=false).s == raw"$\textnormal{\b{R}}\dot{o}\textnormal{\d{X}}$"
 
 @test latexify("ẙĞž"; parse=false).s == raw"$\textnormal{\r{y}}\textnormal{\u{G}}\textnormal{\v{z}}$"
 
 s = 'y' * Char(0x30a) * 'x' * Char(0x302) * 'a' * Char(0x331)
-@test latexify(s; parse=false).s == raw"$\textnormal{\r{y}}\textnormal{\^{x}}\textnormal{\b{a}}$"
+@test latexify(s; parse=false).s == raw"$\textnormal{\r{y}}\hat{x}\textnormal{\b{a}}$"
 
 s = 'Y' * Char(0x30a) * 'X' * Char(0x302) * 'A' * Char(0x331)
-@test latexify(s; parse=false).s == raw"$\textnormal{\r{Y}}\textnormal{\^{X}}\textnormal{\b{A}}$"
+@test latexify(s; parse=false).s == raw"$\textnormal{\r{Y}}\hat{X}\textnormal{\b{A}}$"
 
 s = 'i' * Char(0x308) * 'z' * Char(0x304) * 'e' * Char(0x306)
-@test latexify(s; parse=false).s == raw"$\textnormal{\\\"{i}}\textnormal{\={z}}\textnormal{\u{e}}$"
+@test latexify(s; parse=false).s == raw"$\textnormal{\\\"{i}}\bar{z}\textnormal{\u{e}}$"
 
 s = 'I' * Char(0x308) * 'Z' * Char(0x304) * 'E' * Char(0x306)
-@test latexify(s; parse=false).s == raw"$\textnormal{\\\"{I}}\textnormal{\={Z}}\textnormal{\u{E}}$"
+@test latexify(s; parse=false).s == raw"$\textnormal{\\\"{I}}\bar{Z}\textnormal{\u{E}}$"
+
+@test latexify("ẋ  + ω̂") == raw"$\dot{x} + \hat{\omega}$"
 
 @test latexify(:(iħ * (∂Ψ(𝐫, t) / ∂t) = -ħ^2 / 2m * ΔΨ(𝐫, t) + V * Ψ(𝐫, t))).s ==
-    raw"$i\hslash \cdot \frac{\partial\Psi\left( \mathbf{r}, t \right)}{{\partial}t} = " * 
+    raw"$i\hslash \cdot \frac{\partial\Psi\left( \mathbf{r}, t \right)}{{\partial}t} = " *
     raw"\frac{ - \hslash^{2}}{2 \cdot m} \cdot \Delta\Psi\left( \mathbf{r}, t \right) + V \cdot \Psi\left( \mathbf{r}, t \right)$"
 
 if Sys.islinux()


### PR DESCRIPTION
I would guess that `ȧ` and `â` are more likely to be the mathematical ``\dot{a}`` and ``\hat{a}`` than the text diacritics. Maybe this should be configurable, but I cannot imagine that many people are using the `\textnormal` versions.

Closes #179, Closes #282, Closes #243