### PR TITLE
Separate aligned equations correctly

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -22,7 +22,7 @@ end
 #     KeywordArgument(:template, [:array], "`Bool`", "`false`", "description", [:Any]),
 keyword_arguments = [
     KeywordArgument(:starred, [:align, :array, :arrow, :equation], "`Bool`", "`false`", "Star the environment to prevent equation numbering.", [:Any]),
-    KeywordArgument(:separator, [:align], "`String`", "`\" =& \"`", "Specify how to separate the left hand side and the right.", [:Any]),
+    KeywordArgument(:separator, [:align], "`String`", "`\" &= \"`", "Specify how to separate the left hand side and the right.", [:Any]),
     KeywordArgument(:transpose, [:array, :tabular, :mdtable], "`Bool`", "`true`", "Flip rows for columns.", [:Any]),
     KeywordArgument(:double_linebreak, [:array, :align, :arrow], "`Bool`", "`false`", "Add an extra `\\\\` to the end of the line.", [:Any]),
     KeywordArgument(:bracket, [:align], "`Bool`", "`false`", "Surround variables with square brackets.", [:ParameterizedFunction, :ReactionNetwork]),

--- a/docs/src/tutorials/Catalyst.md
+++ b/docs/src/tutorials/Catalyst.md
@@ -19,8 +19,8 @@ latexify(rn; form=:ode)
 ```
 ```math
 \begin{align}
-\frac{dx}{dt} =& \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} - d_{x} \cdot x - r_{b} \cdot x + r_{u} \cdot y \\
-\frac{dy}{dt} =& p_{y} - d_{y} \cdot y + r_{b} \cdot x - r_{u} \cdot y \\
+\frac{dx}{dt} &= \frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}} - d_{x} \cdot x - r_{b} \cdot x + r_{u} \cdot y \\
+\frac{dy}{dt} &= p_{y} - d_{y} \cdot y + r_{b} \cdot x - r_{u} \cdot y \\
 \end{align}
 ```
 
@@ -30,8 +30,8 @@ latexify(rn; form=:sde)
 ```
 ```math
 \begin{align}
-\frac{dx}{dt} =& \sqrt{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} - \sqrt{d_{x} \cdot x} - \sqrt{r_{b} \cdot x} + \sqrt{r_{u} \cdot y} \\
-\frac{dy}{dt} =& \sqrt{p_{y}} - \sqrt{d_{y} \cdot y} + \sqrt{r_{b} \cdot x} - \sqrt{r_{u} \cdot y} \\
+\frac{dx}{dt} &= \sqrt{\frac{v_{x} \cdot y^{2}}{k_{x}^{2} + y^{2}}} - \sqrt{d_{x} \cdot x} - \sqrt{r_{b} \cdot x} + \sqrt{r_{u} \cdot y} \\
+\frac{dy}{dt} &= \sqrt{p_{y}} - \sqrt{d_{y} \cdot y} + \sqrt{r_{b} \cdot x} - \sqrt{r_{u} \cdot y} \\
 \end{align}
 ```
 

--- a/docs/src/tutorials/latexalign.md
+++ b/docs/src/tutorials/latexalign.md
@@ -14,8 +14,8 @@ outputs:
 
 ```maths
 \begin{align}
-\frac{dx}{dt} =& y^{2} - x \\
-\frac{dy}{dt} =& \frac{x}{y} - y \\
+\frac{dx}{dt} &= y^{2} - x \\
+\frac{dy}{dt} &= \frac{x}{y} - y \\
 \end{align}
 ```
 
@@ -25,8 +25,8 @@ display( latexalign(lhs, rhs))
 ```
 
 \begin{align\*}
-\frac{dx}{dt} =& y^{2} - x \\\\
-\frac{dy}{dt} =& \frac{x}{y} - y \\\\
+\frac{dx}{dt} &= y^{2} - x \\\\
+\frac{dy}{dt} &= \frac{x}{y} - y \\\\
 \end{align\*}
 
 
@@ -48,6 +48,6 @@ latexalign(ode)
 ```
 
 \begin{align}
-\frac{dx}{dt} =& \frac{y}{k_{y} + y} - x \\\\
-\frac{dy}{dt} =& \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} - y \\\\
+\frac{dx}{dt} &= \frac{y}{k_{y} + y} - x \\\\
+\frac{dy}{dt} &= \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} - y \\\\
 \end{align}

--- a/docs/src/tutorials/latexify.md
+++ b/docs/src/tutorials/latexify.md
@@ -50,8 +50,8 @@ If you give two vectors as an argument, they will be displayed as the left-hand-
 latexify(["x/y", :z], Any[2.3, 1//2])
 ```
 \begin{align}
-\frac{x}{y} =& 2.3 \\\\
-z =& \frac{1}{2} \\\\
+\frac{x}{y} &= 2.3 \\\\
+z &= \frac{1}{2} \\\\
 \end{align}
 
 

--- a/docs/src/tutorials/parameterizedfunctions.md
+++ b/docs/src/tutorials/parameterizedfunctions.md
@@ -18,8 +18,8 @@ latexify(ode)
 
 ```math
 \begin{align}
-\frac{dx}{dt} =& \frac{y \cdot y \cdot y}{k_{y\_x} + y} - x - x \\
-\frac{dy}{dt} =& \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} - y \\
+\frac{dx}{dt} &= \frac{y \cdot y \cdot y}{k_{y\_x} + y} - x - x \\
+\frac{dy}{dt} &= \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} - y \\
 \end{align}
 ```
 
@@ -31,8 +31,8 @@ latexify(ode, field=:symfuncs)
 ```
 ```math
 \begin{align}
-\frac{dx}{dt} =& -2 \cdot x + \frac{y^{3}}{k_{y\_x} + y} \\
-\frac{dy}{dt} =&  - y + \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} \\
+\frac{dx}{dt} &= -2 \cdot x + \frac{y^{3}}{k_{y\_x} + y} \\
+\frac{dy}{dt} &=  - y + \frac{x^{n_{x}}}{k_{x}^{n_{x}} + x^{n_{x}}} \\
 \end{align}
 ```
 
@@ -65,9 +65,9 @@ latexify(ode.params, param)
 ```
 ```math
 \begin{align}
-k_{y} =& 3.4 \\
-k_{x} =& 5.2 \\
-n_{x} =& 0.01 \\
+k_{y} &= 3.4 \\
+k_{x} &= 5.2 \\
+n_{x} &= 0.01 \\
 \end{align}
 ```
 

--- a/src/latexalign.jl
+++ b/src/latexalign.jl
@@ -14,9 +14,9 @@ latexalign(lhs, rhs)
 
 ```LaTeX
 \begin{align}
-\frac{dx}{dt} =& y - x \\\\
-\frac{dy}{dt} =& x \cdot z - y \\\\
-\frac{dz}{dt} =& - z \\\\
+\frac{dx}{dt} &= y - x \\\\
+\frac{dy}{dt} &= x \cdot z - y \\\\
+\frac{dz}{dt} &= - z \\\\
 \end{align}
 ```
 
@@ -33,15 +33,15 @@ julia> latexalign(ode)
 ```
 ```LaTeX
 \begin{align}
-\frac{dm}{dt} =& r_{m} \cdot \left( i - m \right) \\\\
-\frac{dy}{dt} =& r_{y} \cdot \left( \frac{p_{y} \cdot i}{m} - y \right) \\\\
+\frac{dm}{dt} &= r_{m} \cdot \left( i - m \right) \\\\
+\frac{dy}{dt} &= r_{y} \cdot \left( \frac{p_{y} \cdot i}{m} - y \right) \\\\
 \end{align}
 ```
 
 """
 latexalign(args...; kwargs...) = process_latexify(args...; kwargs..., env=:align)
 
-function _latexalign(arr::AbstractMatrix; separator=" =& ", double_linebreak=false, starred=false, rows=:all, aligned=false, kwargs...)
+function _latexalign(arr::AbstractMatrix; separator=" &= ", double_linebreak=false, starred=false, rows=:all, aligned=false, kwargs...)
     eol = double_linebreak ? " \\\\\\\\\n" : " \\\\\n"
     arr = latexraw.(arr; kwargs...)
     separator isa String && (separator = fill(separator, size(arr)[1]))

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -4,14 +4,14 @@ using Test
 
 @test latexify(((1.0, 2), (3, 4)); env=:align) == replace(
 raw"\begin{align}
-1.0 =& 3 \\
-2 =& 4
+1.0 &= 3 \\
+2 &= 4
 \end{align}
 ", "\r\n"=>"\n")
 
-@test latexify(((1.0, 2), (3, 4)); separator = [" =& ", " ∈& "], env = :align) == replace(
+@test latexify(((1.0, 2), (3, 4)); separator = [" &= ", " ∈& "], env = :align) == replace(
 raw"\begin{align}
-1.0 =& 3 \\
+1.0 &= 3 \\
 2 ∈& 4
 \end{align}
 ", "\r\n"=>"\n")
@@ -23,8 +23,8 @@ rhs = [1, 2]
 @test latexify(lhs, rhs; env = :aligned) == replace(
 raw"\[
 \begin{aligned}
-a =& 1 \\
-b =& 2
+a &= 1 \\
+b &= 2
 \end{aligned}
 \]
 ", "\r\n"=>"\n")
@@ -34,6 +34,6 @@ b =& 2
 # Latexify.@generate_test latexify(["a=1"], env=:align)
 @test latexify(["a=1"], env = :align) == replace(
 raw"\begin{align}
-a =& 1
+a &= 1
 \end{align}
 ", "\r\n"=>"\n")

--- a/test/latexalign_test.jl
+++ b/test/latexalign_test.jl
@@ -9,10 +9,10 @@ raw"\begin{align}
 \end{align}
 ", "\r\n"=>"\n")
 
-@test latexify(((1.0, 2), (3, 4)); separator = [" &= ", " ∈& "], env = :align) == replace(
+@test latexify(((1.0, 2), (3, 4)); separator = [" &= ", " &∈ "], env = :align) == replace(
 raw"\begin{align}
 1.0 &= 3 \\
-2 ∈& 4
+2 &∈ 4
 \end{align}
 ", "\r\n"=>"\n")
 

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -187,8 +187,8 @@ raw"3 \cdot \left( a < b \leq c < d \leq e > f \leq g \leq h < i = j = k \neq l 
 #### Test the fmt keyword option
 @test latexify([32894823 1.232212 :P_1; :(x / y) 1.0e10 1289.1]; env=:align, fmt="%.2e") == replace(
 raw"\begin{align}
-3.29e+07 =& 1.23e+00 =& P_{1} \\
-\frac{x}{y} =& 1.00e+10 =& 1.29e+03
+3.29e+07 &= 1.23e+00 &= P_{1} \\
+\frac{x}{y} &= 1.00e+10 &= 1.29e+03
 \end{align}
 ", "\r\n"=>"\n")
 

--- a/test/recipe_test.jl
+++ b/test/recipe_test.jl
@@ -117,25 +117,25 @@ raw"\begin{equation}
 
 @test latexify(t2, fmt="%.8f") == replace(
 raw"\begin{align}
-X =& 1.23 \\
-Y =& 232423.42 \\
-\frac{x}{y} =& \frac{4.00}{11.00}
+X &= 1.23 \\
+Y &= 232423.42 \\
+\frac{x}{y} &= \frac{4.00}{11.00}
 \end{align}
 ", "\r\n"=>"\n")
 
 @test latexify(t) == replace(
 raw"\begin{align}
-A =& 1.00 \\
-B =& 2.00 \\
-3.00 =& 3.00
+A &= 1.00 \\
+B &= 2.00 \\
+3.00 &= 3.00
 \end{align}
 ", "\r\n"=>"\n")
 
 @test latexify(t; reverse=true) == replace(
 raw"\begin{align}
-1.00 =& A \\
-2.00 =& B \\
-3.00 =& 3.00
+1.00 &= A \\
+2.00 &= B \\
+3.00 &= 3.00
 \end{align}
 ", "\r\n"=>"\n")
 


### PR DESCRIPTION
Aligned equations were separated by `=&`, which produces an unintended space (https://github.com/SciML/ModelingToolkit.jl/issues/2894) around the equality sign. This changes them to be separated by `&=` instead, which is the most common way to do it and removes the unindented space. See also [this StackExchange post](https://tex.stackexchange.com/questions/41074/relation-spacing-error-using-in-aligned-equations).

Does this have any unintended side effects I am not thinking about?