### PR TITLE
Allow unicode cdot to be considered operator alongside *

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -48,7 +48,15 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
             i == length(args) || (str *= cdot ? " \\cdot " : " ")
         end
         return str
-
+    elseif op in [:⋅]
+        str=""
+        for i ∈ eachindex(args)[2:end]
+            arg = args[i]
+            (precedence(prevOp[i]) < precedence(op) || (ex.args[i] isa Complex && !iszero(ex.args[i].re))) && (arg = "\\left( $arg \\right)")
+            str = string(str, arg)
+            i == length(args) || (" \\cdot ")
+        end
+        return str
     elseif op in [:+]
         str = ""
         for i ∈ eachindex(args)[2:end]


### PR DESCRIPTION
Sometimes you want to assign unicode cdot to dot product, etc but latexify will render it like a function. This PR should allow the unicode cdot to be rendered like the asterisk. It is also immune to kwargs cdot = false because sometimes you want to notate the dot in certain circumstance, etc