### PR TITLE
Fix processing of multiline expressions

### DIFF
--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -37,9 +37,17 @@ function latexify(args...; kwargs...)
     return result
 end
 
+function process_multiline(args...)
+    ## Test if argument contains LineNumberNode, and if true return as array of expressions with LineNumberNodes stripped
+    map(x -> x isa Expr && LineNumberNode in typeof.(x.args) ? filter(y -> !(y isa LineNumberNode), x.args) : x, args)
+end
+
 function process_latexify(args...; kwargs...)
     ## Let potential recipes transform the arguments.
     args, kwargs = apply_recipe(args...; kwargs...)
+
+    ## Split multiline quotes before processing
+    args = process_multiline(args...)
 
     ## If the environment is unspecified, use auto inference.
     env = get(kwargs, :env, :auto)


### PR DESCRIPTION
Wanted to allow the processing of block expressions like:

```julia
quote a = 1
    b = 2
    c = 3
end
```
However the current behaviour of latexify is only to return the last line of the expression.

The external fix is to make a custom function to strip the LineNumberNodes and return as an array:
```julia
latexifyquote = (ex::Expr; kwargs...) -> latexify(filter(x->!(x isa LineNumberNode), ex.args); kwargs...)
```

However I expect this is functionality which should belong in the base package, since it is fairly useful and doesn't (to my knowledge) conflict with any other feature.

The core change is adding a function to check if any argument is a Expr containing LineNumberNode and then splitting it into an array so all lines can be processed correctly. Finding the LineNumberNode is assumed to indicate a multiline Expr only.

