### PR TITLE
Add multiline

### DIFF
--- a/src/latexify_function.jl
+++ b/src/latexify_function.jl
@@ -24,6 +24,7 @@ L"\begin{equation}
 """
 function latexify(args...; kwargs...)
     kwargs = merge(default_kwargs, kwargs)
+    args = process_multiline(args...)
     result = process_latexify(args...; kwargs...)
 
     should_render = get(kwargs, :render, false)
@@ -36,6 +37,8 @@ function latexify(args...; kwargs...)
     AUTO_DISPLAY && display(result)
     return result
 end
+
+process_multiline(args...) = map(x -> x isa Expr && x.head == :block ? filter(y -> !(y isa LineNumberNode), x.args) : x, args)
 
 function process_latexify(args...; kwargs...)
     ## Let potential recipes transform the arguments.

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -211,7 +211,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
 
     ## Use the last expression in a block.
     ## This is somewhat shady but it helps with latexifying functions.
-    ex.head == :block && return args
+    ex.head == :block && return args[end]
 
     ## Sort out type annotations. Mainly for function arguments.
     ex.head == :(::) && length(args) == 1 && return "::$(args[1])"


### PR DESCRIPTION
Idea is to add the ability to latexify expression blocks:

```julia
julia> x = quote
           a = 1
           b = 2
           c = 3
      end

julia> latexify(x, env=:align)
L"\begin{align}
a &= 1 \\
b &= 2 \\
c &= 3
\end{align}
"
```

Since macros are prefixed with LineNumberNodes when contained in expressions I've switched from my original approach of checking for a LineNumberNode object to using the Base.isexpr function to test whether the initial arguement is a block before splitting. This avoids breaking expressions containing macros, however is it incompatible with Julia 1.6 and earlier.

I have also moved this into the main latexify function, since process_multiline should only be called once on the initial arguements, whereas process_latexify can be called multiple times on the same arguments. Don't want to be splitting nested block expressions without considering whether that is something worth doing!