### PR TITLE
Add more array styles, fix amsmath ones

### DIFF
--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -30,20 +30,23 @@ function _latexarray(
         adjustmentstring = string(adjustment)^length(columns)
     end
 
+    need_adjustmentstring = true
+    if arraystyle in AMSMATH_MATRICES ||
+        arraystyle isa NTuple{3,String} && arraystyle[3] == "matrix"
+        need_adjustmentstring = false
+    end
     if arraystyle isa String
         arraystyle = ("", "", arraystyle)
     elseif arraystyle isa Symbol
         arraystyle = ARRAYSTYLES[arraystyle]
     end
 
-    str = string(
-                 arraystyle[1],
-                 "\\begin{",
-                 arraystyle[3],
-                 "}{",
-                 adjustmentstring,
-                 "}\n"
-                )
+    str = string(arraystyle[1], "\\begin{", arraystyle[3], "}")
+    if need_adjustmentstring
+        str = str * string("{", adjustmentstring, "}\n")
+    else
+        str = str * "\n"
+    end
 
     for i in rows, j in columns
         if isassigned(arr, i, j)
@@ -73,9 +76,15 @@ function _latexarray(arg::Tuple; kwargs...)
 end
 
 const ARRAYSTYLES = Dict{Symbol, NTuple{3, String}}(
+                                                                         :array=>("", "", "array"),
                                         :square=>("\\left[\n", "\n\\right]", "array"),
                                         :round=>("\\left(\n", "\n\\right)", "array"),
                                         :curly=>("\\left\\{\n", "\n\\right\\}", "array"),
+                                        :matrix=>("","","matrix"),
                                         :pmatrix=>("","","pmatrix"),
                                         :bmatrix=>("","","bmatrix"),
+                                        :Bmatrix=>("","","Bmatrix"),
+                                        :vmatrix=>("","","vmatrix"),
+                                        :Vmatrix=>("","","Vmatrix"),
                                        )
+const AMSMATH_MATRICES = [:matrix, :pmatrix, :bmatrix, :Bmatrix, :vmatrix, :Vmatrix]

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -87,6 +87,15 @@ raw"\begin{equation}
 using OffsetArrays
 @test latexify(OffsetArray(arr, -1:0, 3:4)) == latexify(arr)
 
+@test latexify(arr; arraystyle = :array) == replace(
+raw"\begin{equation}
+\begin{array}{cc}
+1 & 2 \\
+3 & 4 \\
+\end{array}
+\end{equation}
+", "\r\n"=>"\n")
+
 @test latexify(arr; arraystyle = :square) == replace(
 raw"\begin{equation}
 \left[
@@ -120,9 +129,18 @@ raw"\begin{equation}
 \end{equation}
 ", "\r\n"=>"\n")
 
+@test latexify(arr; arraystyle = :matrix) == replace(
+raw"\begin{equation}
+\begin{matrix}
+1 & 2 \\
+3 & 4 \\
+\end{matrix}
+\end{equation}
+", "\r\n"=>"\n")
+
 @test latexify(arr; arraystyle = :pmatrix) == replace(
 raw"\begin{equation}
-\begin{pmatrix}{cc}
+\begin{pmatrix}
 1 & 2 \\
 3 & 4 \\
 \end{pmatrix}
@@ -131,10 +149,37 @@ raw"\begin{equation}
 
 @test latexify(arr; arraystyle = :bmatrix) == replace(
 raw"\begin{equation}
-\begin{bmatrix}{cc}
+\begin{bmatrix}
 1 & 2 \\
 3 & 4 \\
 \end{bmatrix}
+\end{equation}
+", "\r\n"=>"\n")
+
+@test latexify(arr; arraystyle = :Bmatrix) == replace(
+raw"\begin{equation}
+\begin{Bmatrix}
+1 & 2 \\
+3 & 4 \\
+\end{Bmatrix}
+\end{equation}
+", "\r\n"=>"\n")
+
+@test latexify(arr; arraystyle = :vmatrix) == replace(
+raw"\begin{equation}
+\begin{vmatrix}
+1 & 2 \\
+3 & 4 \\
+\end{vmatrix}
+\end{equation}
+", "\r\n"=>"\n")
+
+@test latexify(arr; arraystyle = :Vmatrix) == replace(
+raw"\begin{equation}
+\begin{Vmatrix}
+1 & 2 \\
+3 & 4 \\
+\end{Vmatrix}
 \end{equation}
 ", "\r\n"=>"\n")
 


### PR DESCRIPTION
Close #318 

Amsmath matrix styles don't need alignment strings, so this PR removes them. Also added a couple of array styles for consistency.