### PR TITLE
Use thin \, space for multiplication when cdot = false

### DIFF
--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -37,7 +37,7 @@ keyword_arguments = [
     KeywordArgument(:imaginary_unit, [:mdtable, :tabular, :align, :array, :raw, :inline], "`String`", "`\"\\\\mathit{i}\"`", "The symbol to use to represent the imaginary unit", [:Any]),
     KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
     KeywordArgument(:convert_unicode, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Convert unicode characters to latex commands, for example `α` to `\\alpha`", [:Any]),
-    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\\cdot` or just a space to represent multiplication.", [:Any]),
+    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\\cdot` or just a thin `\\,` space to represent multiplication.", [:Any]),
     KeywordArgument(:symbolic, [:align], "`Bool`", "`false`", "Use symbolic calculations to clean up the expression.", [:ReactionNetwork]),
     KeywordArgument(:clean, [:align], "`Bool`", "`false`", "Clean out `1*` terms. Only useful for Catalyst (then named DiffEqBiological) versions 3.4 or below.", [:ReactionNetwork]),
     KeywordArgument(:rows, [:align], "Iterable or symol", ":all", "Which rows to include in the output.", [:Any]),

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -45,7 +45,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
             arg = args[i]
             (precedence(prevOp[i]) < precedence(op) || (ex.args[i] isa Complex && !iszero(ex.args[i].re))) && (arg = "\\left( $arg \\right)")
             str = string(str, arg)
-            i == length(args) || (str *= cdot ? " \\cdot " : " ")
+            i == length(args) || (str *= cdot ? " \\cdot " : " \\, ")
         end
         return str
 

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -4,23 +4,23 @@ using Test
 
 
 #inline
-@test latexify(:(x * y); env=:inline, cdot=false) == raw"$x y$"
+@test latexify(:(x * y); env=:inline, cdot=false) == raw"$x \, y$"
 
 @test latexify(:(x * y); env=:inline, cdot=true) == raw"$x \cdot y$"
 
 @test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=false) ==
-raw"$x \left( y + z \right) y \left( z + a \right) \left( z + b \right)$"
+raw"$x \, \left( y + z \right) \, y \, \left( z + a \right) \, \left( z + b \right)$"
 
 @test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=true) ==
 raw"$x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)$"
 
 # raw
-@test latexify(:(x * y); env=:raw, cdot=false) == raw"x y"
+@test latexify(:(x * y); env=:raw, cdot=false) == raw"x \, y"
 
 @test latexify(:(x * y); env=:raw, cdot=true) == raw"x \cdot y"
 
 @test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=false) ==
-raw"x \left( y + z \right) y \left( z + a \right) \left( z + b \right)"
+raw"x \, \left( y + z \right) \, y \, \left( z + a \right) \, \left( z + b \right)"
 
 @test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=true) ==
 raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)"
@@ -30,7 +30,7 @@ raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left(
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
-x y & x \left( y + z \right) y \left( z + a \right) \left( z + b \right) \\
+x \, y & x \, \left( y + z \right) \, y \, \left( z + a \right) \, \left( z + b \right) \\
 \end{array}
 \right]
 \end{equation}
@@ -53,12 +53,12 @@ x \cdot y & x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdo
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]
 
 @test latexify(arr; env=:mdtable, cdot=false) ==
-Markdown.md"| $x \left( y - 1 \right)$ |
-| ------------------------:|
-|                    $1.0$ |
-|                      $6$ |
-|                $x - 2 y$ |
-|                   $symb$ |
+Markdown.md"| $x \, \left( y - 1 \right)$ |
+| -------------------------:|
+|                     $1.0$ |
+|                       $6$ |
+|              $x - 2 \, y$ |
+|                    $symb$ |
 "
 
 @test latexify(arr; env=:mdtable, cdot=true) ==

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -14,7 +14,7 @@ raw"$x \cdot y$"
 set_default(cdot = false)
 
 @test latexify("x * y") == 
-raw"$x y$"
+raw"$x \, y$"
 
 @test get_default() == Dict{Symbol,Any}(:cdot => false)
 


### PR DESCRIPTION
Problem: currently `latexify("A*B"; cdot=false)` and `latexify("AB")` are visually indistinguishable, because `$A B$` and `$AB$` renders the same in Latex as $AB$.

Solution: instead of a blank space, use the thin space `\,` as a "multiplication operator" when `cdot = false`. Then `latexify("A*B"; cdot=false)` gives `$A \, B`, i.e. $A \\, B$, which looks slightly different from $AB$. I think this is slightly better default behavior.