### PR TITLE
Replace boolean cdot keyword argument in favor of more flexible mult_symbol string

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -156,7 +156,7 @@ Note that this changes Latexify.jl from within and should therefore only be used
 
 The calls are additive so that a new call with 
 ```julia
-set_default(cdot = false)
+set_default(mult_symbol = "")
 ```
 will not cancel out the changes we just made to `fmt` and `convert_unicode`. 
 

--- a/docs/src/table_generator.jl
+++ b/docs/src/table_generator.jl
@@ -37,7 +37,7 @@ keyword_arguments = [
     KeywordArgument(:imaginary_unit, [:mdtable, :tabular, :align, :array, :raw, :inline], "`String`", "`\"\\\\mathit{i}\"`", "The symbol to use to represent the imaginary unit", [:Any]),
     KeywordArgument(:escape_underscores, [:mdtable, :mdtext], "`Bool`", "`false`", "Prevent underscores from being interpreted as formatting.", [:Any]),
     KeywordArgument(:convert_unicode, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Convert unicode characters to latex commands, for example `α` to `\\alpha`", [:Any]),
-    KeywordArgument(:cdot, [:mdtable, :tabular, :align, :array, :raw, :inline], "`Bool`", "`true`", "Toggle between using `\\cdot` or just a space to represent multiplication.", [:Any]),
+    KeywordArgument(:mult_symbol, [:mdtable, :tabular, :align, :array, :raw, :inline], "`String`", "`\"\\\\cdot\"`", "Specify the symbol to use for the multiplication operator (`\"\"` for juxtaposition).", [:Any]),
     KeywordArgument(:symbolic, [:align], "`Bool`", "`false`", "Use symbolic calculations to clean up the expression.", [:ReactionNetwork]),
     KeywordArgument(:clean, [:align], "`Bool`", "`false`", "Clean out `1*` terms. Only useful for Catalyst (then named DiffEqBiological) versions 3.4 or below.", [:ReactionNetwork]),
     KeywordArgument(:rows, [:align], "Iterable or symol", ":all", "Which rows to include in the output.", [:Any]),

--- a/src/default_kwargs.jl
+++ b/src/default_kwargs.jl
@@ -10,7 +10,7 @@ you call it multiple times, defaults will be added or replaced, but not reset.
 
 Example: 
 ```julia
-set_default(cdot = false, transpose = true)
+set_default(mult_symbol = "", transpose = true)
 ```
 
 To reset the defaults that you have set, use `reset_default`.

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -7,11 +7,11 @@ a parenthesis is needed.
 
 """
 function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
-    # If we used `cdot` and `index` as keyword arguments before `kwargs...`
+    # If we used `mult_symbol` and `index` as keyword arguments before `kwargs...`
     # and they are indeed contained in `kwargs`, they would get lost when
     # passing `kwargs...` to `latexraw`below. Thus, we need to set default
     # values as follows.
-    cdot = get(kwargs, :cdot, true)
+    mult_symbol = get(kwargs, :mult_symbol, "\\cdot")
     index = get(kwargs, :index, :bracket)
 
     op = ex.args[1]
@@ -45,7 +45,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
             arg = args[i]
             (precedence(prevOp[i]) < precedence(op) || (ex.args[i] isa Complex && !iszero(ex.args[i].re))) && (arg = "\\left( $arg \\right)")
             str = string(str, arg)
-            i == length(args) || (str *= cdot ? " \\cdot " : " ")
+            i == length(args) || (str *= mult_symbol == "" ? " " : " $mult_symbol ")
         end
         return str
 

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -14,6 +14,12 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
     mult_symbol = get(kwargs, :mult_symbol, "\\cdot")
     index = get(kwargs, :index, :bracket)
 
+    if haskey(kwargs, :cdot)
+        cdot = kwargs[:cdot]
+        mult_symbol = cdot ? "\\cdot" : ""
+        Base.depwarn("Latexify received the deprecated keyword argument cdot = $cdot and converted it to mult_symbol = \"$mult_symbol\". Pass the latter directly to remove this warning.", :latexoperation)
+    end
+
     op = ex.args[1]
     string(op)[1] == '.' && (op = Symbol(string(op)[2:end]))
 

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -73,3 +73,9 @@ Markdown.md"| $x \cdot \left( y - 1 \right)$ |
 
 
 
+# Deprecation of cdot = ... in favor of mult_symbol = ...
+# (cdot takes precedence over mult_symbol)
+@test_deprecated latexify(:(x * y); cdot=false)
+@test_deprecated latexify(:(x * y); cdot=true)
+@test latexify(:(x * y); mult_symbol="garbage", cdot=false) == latexify(:(x * y); mult_symbol="")
+@test latexify(:(x * y); mult_symbol="garbage", cdot=true) == latexify(:(x * y); mult_symbol="\\cdot")

--- a/test/cdot_test.jl
+++ b/test/cdot_test.jl
@@ -4,29 +4,29 @@ using Test
 
 
 #inline
-@test latexify(:(x * y); env=:inline, cdot=false) == raw"$x y$"
+@test latexify(:(x * y); env=:inline, mult_symbol="") == raw"$x y$"
 
-@test latexify(:(x * y); env=:inline, cdot=true) == raw"$x \cdot y$"
+@test latexify(:(x * y); env=:inline, mult_symbol="\\cdot") == raw"$x \cdot y$"
 
-@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=false) ==
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, mult_symbol="") ==
 raw"$x \left( y + z \right) y \left( z + a \right) \left( z + b \right)$"
 
-@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, cdot=true) ==
+@test latexify(:(x*(y+z)*y*(z+a)*(z+b)); env=:inline, mult_symbol="\\cdot") ==
 raw"$x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)$"
 
 # raw
-@test latexify(:(x * y); env=:raw, cdot=false) == raw"x y"
+@test latexify(:(x * y); env=:raw, mult_symbol="") == raw"x y"
 
-@test latexify(:(x * y); env=:raw, cdot=true) == raw"x \cdot y"
+@test latexify(:(x * y); env=:raw, mult_symbol="\\cdot") == raw"x \cdot y"
 
-@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=false) ==
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, mult_symbol="") ==
 raw"x \left( y + z \right) y \left( z + a \right) \left( z + b \right)"
 
-@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, cdot=true) ==
+@test latexify(:(x * (y + z) * y * (z + a) * (z + b)); env=:raw, mult_symbol="\\cdot") ==
 raw"x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdot \left( z + b \right)"
 
 # array
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, cdot=false) == replace(
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, mult_symbol="") == replace(
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -36,7 +36,7 @@ x y & x \left( y + z \right) y \left( z + a \right) \left( z + b \right) \\
 \end{equation}
 ", "\r\n"=>"\n")
 
-@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, cdot=true) == replace(
+@test latexify( [:(x*y), :(x*(y+z)*y*(z+a)*(z+b))]; env=:equation, transpose=true, mult_symbol="\\cdot") == replace(
 raw"\begin{equation}
 \left[
 \begin{array}{cc}
@@ -52,7 +52,7 @@ x \cdot y & x \cdot \left( y + z \right) \cdot y \cdot \left( z + a \right) \cdo
 # mdtable
 arr = ["x*(y-1)", 1.0, 3*2, :(x-2y), :symb]
 
-@test latexify(arr; env=:mdtable, cdot=false) ==
+@test latexify(arr; env=:mdtable, mult_symbol="") ==
 Markdown.md"| $x \left( y - 1 \right)$ |
 | ------------------------:|
 |                    $1.0$ |
@@ -61,7 +61,7 @@ Markdown.md"| $x \left( y - 1 \right)$ |
 |                   $symb$ |
 "
 
-@test latexify(arr; env=:mdtable, cdot=true) ==
+@test latexify(arr; env=:mdtable, mult_symbol="\\cdot") ==
 Markdown.md"| $x \cdot \left( y - 1 \right)$ |
 | ------------------------------:|
 |                          $1.0$ |

--- a/test/latexify_test.jl
+++ b/test/latexify_test.jl
@@ -11,19 +11,19 @@ test_array = ["x/y * d" :x ; :( (t_sub_sub - x)^(2*p) ) 3//4 ]
 @test latexify("x * y") == 
 raw"$x \cdot y$"
 
-set_default(cdot = false)
+set_default(mult_symbol = "")
 
 @test latexify("x * y") == 
 raw"$x y$"
 
-@test get_default() == Dict{Symbol,Any}(:cdot => false)
+@test get_default() == Dict{Symbol,Any}(:mult_symbol => "")
 
-set_default(cdot = true, transpose = true)
+set_default(mult_symbol = "\\cdot", transpose = true)
 
-@test get_default() == Dict{Symbol,Any}(:cdot => true,:transpose => true)
-@test get_default(:cdot) == true
-@test get_default(:cdot, :transpose) == (true, true)
-@test get_default([:cdot, :transpose]) == Bool[1, 1]
+@test get_default() == Dict{Symbol,Any}(:mult_symbol => "\\cdot",:transpose => true)
+@test get_default(:mult_symbol) == "\\cdot"
+@test get_default(:mult_symbol, :transpose) == ("\\cdot", true)
+@test get_default([:mult_symbol, :transpose]) == ["\\cdot", true]
 
 reset_default()
 @test get_default() == Dict{Symbol,Any}()


### PR DESCRIPTION
Follow-up to https://github.com/korsbo/Latexify.jl/pull/323; see discussion there.

@gustaphe I figured the simplest way of handling the deprecation of `cdot` in code is to convert it to the equivalent `mult_symbol`. This means `cdot` takes precedence over `mult_symbol` in the event that they are both set, which is the opposite of what we agreed. I can argue both ways; if you think it is more natural for `mult_symbol` to take priority, or there is anything else, I am happy to update it.