### PR TITLE
Differentiate between broadcasting and property access

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -117,8 +117,17 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
     end
 
     if ex.head == :.
-        ex.head = :call
-        # op = string(op, ".") ## Signifies broadcasting.
+        if length(ex.args) >= 2 && (
+                                    ex.args[2] isa Expr && ex.args[2].head == :tuple
+                                   ||
+                                   ex.args[2] isa String
+                                  )
+            # broadcasted function call `f.(x)`
+            ex.head = :call
+        else
+            # property or field `f.x`
+            return "$(ex.args[1]).$(ex.args[2] isa QuoteNode ? ex.args[2].value : ex.args[2])"
+        end
     end
 
     if op in keys(binary_operators) && length(args) == 3
@@ -173,7 +182,7 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
     ## Leave math italics for single-character operator names (e.g., f(x)).
     # convert subscript symbols to \_ if necessary, and make long function names
     # upright
-    opname = convert_subscript(string(op); function_name=true, kwargs...)
+    opname = operator_name(op; kwargs...);
 
     if ex.head == :ref
         if index == :subscript
@@ -290,7 +299,18 @@ function convert_subscript(str::String; snakecase=false, function_name=false, kw
     end
 end
 
-convert_subscript(sym::Symbol, kwargs...) = convert_subscript(string(sym), kwargs...)
+convert_subscript(sym::Symbol; kwargs...) = convert_subscript(string(sym); kwargs...)
+convert_subscript(n::Number; kwargs...) = convert_subscript(string(n); kwargs...)
+
+operator_name(sym; kwargs...) = convert_subscript(sym; kwargs..., function_name=true)
+operator_name(lnn::LineNumberNode;kwargs...) = ""
+function operator_name(ex::Expr; kwargs...)
+    if ex.head == :. && ex.args[2] isa QuoteNode
+        return convert_subscript(ex.args[1]; function_name=true, kwargs...) * "." * convert_subscript(ex.args[2].value; function_name=true, kwargs...)
+    else
+        error("I don't know what this is")
+    end
+end
 
 """
     precedence(op)

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -164,7 +164,12 @@ raw"$\left( \frac{3}{2} \right)^{2}$", "\r\n"=>"\n")
 ### Test broadcasting
 @test latexraw(:(fun.((a, b)))) == raw"\mathrm{fun}\left( a, b \right)"
 
+### Test field/property extraction
+@test latexraw(:(Foo.foo)) == raw"Foo.foo"
+@test latexraw(:(Foo.fun(a, b))) == raw"\mathrm{Foo.fun}\left( a, b \right)"
 
+### Test combined broadcasting and field extraction
+@test latexraw(:(Foo.fun.((a, b)))) == raw"\mathrm{Foo.fun}\left( a, b \right)"
 
 
 ### Test for correct signs in nested sums/differences.


### PR DESCRIPTION
I'm surprised how intransparently the parser differentiates broadcasting (`f.(x)`) and property/field access (`A.x`). Here's an implementation that solves #321 (sorry, just recently noticed this one).

close #321 