### PR TITLE
Siunitx formatter

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,6 +84,7 @@ You can control the formatting of numbers by passing any of the following to the
 - a formatter supplied by Latexify.jl, for example `fmt = FancyNumberFormatter(2)` (thanks to @simeonschaub). You can pass any of these formatters an integer argument which specifies how many significant digits you want.
   - `FancyNumberFormatter()` replaces the exponent notation, from `1.2e+3` to `1.2 \cdot 10^3`. 
   - `StyledNumberFormatter()` replaces the exponent notation, from `1.2e+3` to `1.2 \mathrm{e} 3`.
+  - `SiunitxNumberFormatter()` uses the `siunitx` package's `\num`, so all the formatting is offloaded on the `\LaTeX` engine. Formatting arguments can be supplied as a string to the keyword argument `format_options`. If your `siunitx` installation is version 2 or older, use the keyword argument `version=2` to replace `\num` by `\si`.
 
 
 
@@ -91,7 +92,6 @@ Examples:
 ```@example main
 latexify(12345.678; fmt="%.1e")
 ```
-$1.2e+04$
 
 ```@example main
 latexify([12893.1 1.328e2; "x/y" 7832//2378]; fmt=FancyNumberFormatter(3))
@@ -112,6 +112,12 @@ using Format
 latexify([12893.1 1.328e2]; fmt=x->format(round(x, sigdigits=2), autoscale=:metric))
 ```
 
+```@example main
+str = latexify(12345.678; fmt=SiunitxNumberFormatter(format_options="round-mode=places,round-precision=1", version=3))
+render(str, MIME"image/png"(); name="siunitx", open=false) # hide
+replace(string(str), "\$"=>"`") # hide
+```
+![SI unit example](siunitx.png)
 
 ## Automatic copying to clipboard
 The strings that you would see when using print on any of the above functions can be automatically copied to the clipboard if you so specify.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,7 +114,7 @@ latexify([12893.1 1.328e2]; fmt=x->format(round(x, sigdigits=2), autoscale=:metr
 
 ```@example main
 str = latexify(12345.678; fmt=SiunitxNumberFormatter(format_options="round-mode=places,round-precision=1", version=3))
-render(str, MIME"image/png"(); name="siunitx", open=false) # hide
+#render(str, MIME"image/png"(); name="siunitx", open=false) # hide
 replace(string(str), "\$"=>"`") # hide
 ```
 ![SI unit example](siunitx.png)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -114,10 +114,8 @@ latexify([12893.1 1.328e2]; fmt=x->format(round(x, sigdigits=2), autoscale=:metr
 
 ```@example main
 str = latexify(12345.678; fmt=SiunitxNumberFormatter(format_options="round-mode=places,round-precision=1", version=3))
-#render(str, MIME"image/png"(); name="siunitx", open=false) # hide
 replace(string(str), "\$"=>"`") # hide
 ```
-![SI unit example](siunitx.png)
 
 ## Automatic copying to clipboard
 The strings that you would see when using print on any of the above functions can be automatically copied to the clipboard if you so specify.

--- a/docs/src/tutorials/latextabular.md
+++ b/docs/src/tutorials/latextabular.md
@@ -28,3 +28,7 @@ $\frac{x}{y}$ & $1.0$\\
 $y^{n}$ & $\alpha\left( x \right)$\\
 \end{tabular}
 ```
+
+The adjustments can be set per column by providing a vector like `[:c, :l, :r]`.
+If you want to use the `S` column type from `siunitx`, set `latex=false, adjustment=:S`.
+Some post-adjustment may be necessary.

--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -21,7 +21,7 @@ export latexify, md, copy_to_clipboard, auto_display, set_default, get_default,
 ## Allow some backwards compatibility until its time to deprecate.
 export latexequation, latexarray, latexalign, latexraw, latexinline, latextabular, mdtable
 
-export StyledNumberFormatter, FancyNumberFormatter
+export StyledNumberFormatter, FancyNumberFormatter, SiunitxNumberFormatter
 
 COPY_TO_CLIPBOARD = false
 function copy_to_clipboard(x::Bool)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,7 @@ add_brackets(s::Any, vars) = s
 default_packages(s) = vcat(
                            ["amssymb", "amsmath", "unicode-math"],
                            occursin("\\ce{", s) ? ["mhchem"] : [],
-                           any(occursin.(["\\si", "\\SI", "\\num", "\\qty"], s)) ? ["siunitx"] : [],
+                           any(x->occursin(prod(x), s), Iterators.product(["\\si", "\\SI", "\\num", "\\qty"], ["{", "range{", "list{", "product{"])) ? ["siunitx"] : [],
                           )
 
 function _writetex(s::LaTeXString;

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -154,7 +154,8 @@ function render(s::LaTeXString, mime::MIME"image/png";
         # prefer tex -> pdf -> png instead
         if convert === :gs
             aux_mime = MIME("application/pdf")
-            cmd = `gs -sDEVICE=pngalpha -dTextAlphaBits=4 -r$dpi -o $name.$ext $aux_name.pdf`
+            ghostscript_command = get(ENV, "GHOSTSCRIPT", "gs")
+            cmd = `$ghostscript_command -sDEVICE=pngalpha -dTextAlphaBits=4 -r$dpi -o $name.$ext $aux_name.pdf`
         elseif convert === :dvipng
             aux_mime = MIME("application/x-dvi")
             deb = debug ? [] : ["-q"]

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,7 +3,11 @@ add_brackets(ex::Expr, vars) = postwalk(x -> x in vars ? "\\left[ $(convert_subs
 add_brackets(arr::AbstractArray, vars) = [add_brackets(element, vars) for element in arr]
 add_brackets(s::Any, vars) = s
 
-default_packages(s) = vcat(["amssymb", "amsmath", "unicode-math"], occursin("\\ce{", s) ? ["mhchem"] : [])
+default_packages(s) = vcat(
+                           ["amssymb", "amsmath", "unicode-math"],
+                           occursin("\\ce{", s) ? ["mhchem"] : [],
+                           any(occursin.(["\\si", "\\SI", "\\num", "\\qty"], s)) ? ["siunitx"] : [],
+                          )
 
 function _writetex(s::LaTeXString;
         name=tempname(),

--- a/test/latextabular_test.jl
+++ b/test/latextabular_test.jl
@@ -109,3 +109,21 @@ $a$ & $\frac{x}{k + x}$\\
 $b$ & $x - y$\\
 \end{tabular}
 ", "\r\n"=>"\n")
+
+@test latexify(d; env=:tabular, latex=false, fmt=SiunitxNumberFormatter()) == replace(
+raw"\begin{tabular}{cc}
+A & B\\
+\num{11} & X\\
+\num{12} & Y\\
+\num{13} & Z\\
+\end{tabular}
+", "\r\n"=>"\n")
+
+@test latexify(d; env=:tabular, latex=false, fmt=SiunitxNumberFormatter(), adjustment=:S) == replace(
+raw"\begin{tabular}{SS}
+A & B\\
+11 & X\\
+12 & Y\\
+13 & Z\\
+\end{tabular}
+", "\r\n"=>"\n")

--- a/test/numberformatters_test.jl
+++ b/test/numberformatters_test.jl
@@ -26,3 +26,26 @@ y = 0xf43
 @test SiunitxNumberFormatter(version=2)(x) == "\\si{-2.34728979e8}"
 @test SiunitxNumberFormatter(format_options="something")(x) == "\\num[something]{-2.34728979e8}"
 @test SiunitxNumberFormatter(format_options="[something]")(x) == "\\num[something]{-2.34728979e8}"
+
+@test SiunitxNumberFormatter()([1,2,4]) == "\\numlist{1;2;4}"
+@test SiunitxNumberFormatter()(1:4) == "\\numrange{1}{4}"
+
+@test Latexify.siunitxcommand(:number, 2) == "si"
+@test Latexify.siunitxcommand(:quantity, 2) == "SI"
+@test Latexify.siunitxcommand(:numberrange, 2) == "sirange"
+@test Latexify.siunitxcommand(:quantityrange, 2) == "SIrange"
+@test Latexify.siunitxcommand(:numberlist, 2) == "silist"
+@test Latexify.siunitxcommand(:quantitylist, 2) == "SIlist"
+@test Latexify.siunitxcommand(:numberproduct, 2) == "siproduct"
+@test Latexify.siunitxcommand(:quantityproduct, 2) == "SIproduct"
+
+@test Latexify.siunitxcommand(:number, 3) == "num"
+@test Latexify.siunitxcommand(:quantity, 3) == "qty"
+@test Latexify.siunitxcommand(:numberrange, 3) == "numrange"
+@test Latexify.siunitxcommand(:quantityrange, 3) == "qtyrange"
+@test Latexify.siunitxcommand(:numberlist, 3) == "numlist"
+@test Latexify.siunitxcommand(:quantitylist, 3) == "qtylist"
+@test Latexify.siunitxcommand(:numberproduct, 3) == "numproduct"
+@test Latexify.siunitxcommand(:quantityproduct, 3) == "qtyproduct"
+
+@test_throws ArgumentError Latexify.siunitxcommand(:nonsense, 1)

--- a/test/numberformatters_test.jl
+++ b/test/numberformatters_test.jl
@@ -21,3 +21,8 @@ xne = -23.4728979e-7
 y = 0xf43
 
 @test StyledNumberFormatter()(y) == FancyNumberFormatter()(y) == "\\mathtt{0x0f43}"
+
+@test SiunitxNumberFormatter()(x) == "\\num{-2.34728979e8}"
+@test SiunitxNumberFormatter(version=2)(x) == "\\si{-2.34728979e8}"
+@test SiunitxNumberFormatter(format_options="something")(x) == "\\num[something]{-2.34728979e8}"
+@test SiunitxNumberFormatter(format_options="[something]")(x) == "\\num[something]{-2.34728979e8}"


### PR DESCRIPTION
Create a number formatter that outputs siunitx commands (`\num`, typically). Might seem a little like overkill for `Latexify`, but for `UnitfulLatexify` this will make things more unified. And this will link into the `Unitful` extension in `Plots`.

```julia
julia> @latexify x=1.375 fmt=SiunitxNumberFormatter()
L"$x = \num{1.375}$"
```

Needed a way to replace `gs` with `gswin64c` on Windows for documentation, so I'm sneaking that in here too.