### PR TITLE
Add range operator

### DIFF
--- a/src/Latexify.jl
+++ b/src/Latexify.jl
@@ -59,6 +59,7 @@ include("error.jl")
 include("numberformatters.jl")
 
 include("latexify_function.jl")
+include("internal_recipes.jl")
 
 ### Add support for additional packages without adding them as dependencies.
 ### Requires on <1.9 and weakdeps/extensions on >=1.9

--- a/src/internal_recipes.jl
+++ b/src/internal_recipes.jl
@@ -9,7 +9,7 @@ end
     return :($(x.start) : $(step(x)) : $(x.stop))
 end
 
-@latexrecipe function f(x::StepRangeLen{T, R, S, L}; expand_ranges=false, expand_step_ranges=true) where {T, R, S, L}
+@latexrecipe function f(x::StepRangeLen{T, <:Any, <:Any}; expand_ranges=false, expand_step_ranges=true) where {T}
     (expand_ranges || expand_step_ranges) && return collect(x)
     return :($(T(x.ref + (x.offset-1)*step(x))) : $(T(x.step)) : $(T(x.ref + (x.len-1)*x.step)))
 end

--- a/src/internal_recipes.jl
+++ b/src/internal_recipes.jl
@@ -1,0 +1,18 @@
+
+@latexrecipe function f(x::UnitRange; expand_ranges=false)
+    expand_ranges && return collect(x)
+    return :($(x.start) : $(x.stop))
+end
+
+@latexrecipe function f(x::StepRange; expand_ranges=false, expand_step_ranges=true)
+    (expand_ranges || expand_step_ranges) && return collect(x)
+    return :($(x.start) : $(step(x)) : $(x.stop))
+end
+
+@latexrecipe function f(x::StepRangeLen{T, R, S, L}; expand_ranges=false, expand_step_ranges=true) where {T, R, S, L}
+    (expand_ranges || expand_step_ranges) && return collect(x)
+    return :($(T(x.ref + (x.offset-1)*step(x))) : $(T(x.step)) : $(T(x.ref + (x.len-1)*x.step)))
+end
+
+
+

--- a/src/latexarray.jl
+++ b/src/latexarray.jl
@@ -67,7 +67,6 @@ function _latexarray(
     return latexstr
 end
 
-
 _latexarray(args::AbstractArray...; kwargs...) = _latexarray(safereduce(hcat, args); kwargs...)
 _latexarray(arg::AbstractDict; kwargs...) = _latexarray(collect(keys(arg)), collect(values(arg)); kwargs...)
 _latexarray(arg::Tuple...; kwargs...) = _latexarray([collect(i) for i in arg]...; kwargs...)

--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -114,6 +114,8 @@ function latexoperation(ex::Expr, prevOp::AbstractArray; kwargs...)::String
         return "$(args[1]) = $(args[2])"
     elseif op == :(!)
         return "\\neg $(args[2])"
+    elseif op == :(:) && length(args) == 4
+        return "$(args[2]) \\underset{$(args[3])}{$(binary_operators[:(:)])} $(args[4])"
     end
 
     if ex.head == :.
@@ -320,6 +322,7 @@ function precedence(op::Symbol)
     startswith(string(op), "unary") && return Base.prec_power # Putting unary on par with :^, because there are no integers between 14 and 15. Should consider putting it with :<< instead
     op ∈ [:comparison, :issubset] && return Base.prec_comparison
     #op == :∀ && return Base.prec_control_flow
+    op == :(:) && return 10
     prec = Base.operator_precedence(op)
     prec == 0 && return 100 # Base treats unknown as parenthesizable, we want no parenthesis if uncertain
     return prec
@@ -328,5 +331,6 @@ function associativity(op::Symbol)
     startswith(string(op), "unary") && return :right
     op == :comparison && return :none
     op == :issubset && return :none
+
     return Base.operator_associativity(op)
 end

--- a/src/symbol_translations.jl
+++ b/src/symbol_translations.jl
@@ -152,6 +152,7 @@ const binary_operators = Dict(
                             arithmetic_operators...,
                             :(=>) => "\\Rightarrow",
                             :⟹ => "\\Longrightarrow",
+                            :(:) => "\\mathrel{\\ldotp\\mkern-2.5mu\\ldotp}"
                            )
 
 const unary_operators = Dict(

--- a/test/latexarray_test.jl
+++ b/test/latexarray_test.jl
@@ -300,3 +300,38 @@ x & \cdot \\
 \right]
 \end{equation}
 ", "\r\n"=>"\n")
+
+@test latexify(:((1:3) .+ (1:2:5) .+ 3*(1:3))) == raw"$\left( 1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3 \right) + \left( 1 \underset{2}{\mathrel{\ldotp\mkern-2.5mu\ldotp}} 5 \right) + 3 \cdot \left( 1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3 \right)$"
+@test latexify(:($(1:3) .+ $(1:2:5) .+ $(3*(1:3)))) == replace(raw"$1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3 + \left[
+\begin{array}{c}
+1 \\
+3 \\
+5 \\
+\end{array}
+\right] + \left[
+\begin{array}{c}
+3 \\
+6 \\
+9 \\
+\end{array}
+\right]$", "\r\n"=>"\n")
+@test latexify(:($(1:3) .+ $(1:2:5) .+ $(3*(1:3))), expand_step_ranges=false) == raw"$1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3 + 1 \underset{2}{\mathrel{\ldotp\mkern-2.5mu\ldotp}} 5 + 3 \underset{3}{\mathrel{\ldotp\mkern-2.5mu\ldotp}} 9$"
+@test latexify(:($(1:3) .+ $(1:2:5) .+ $(3*(1:3))), expand_ranges=true) == latexify(:($(1:3) .+ $(1:2:5) .+ $(3*(1:3))), expand_ranges=true, expand_step_ranges=false) == replace(raw"$\left[
+\begin{array}{c}
+1 \\
+2 \\
+3 \\
+\end{array}
+\right] + \left[
+\begin{array}{c}
+1 \\
+3 \\
+5 \\
+\end{array}
+\right] + \left[
+\begin{array}{c}
+3 \\
+6 \\
+9 \\
+\end{array}
+\right]$", "\r\n"=>"\n")

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -194,6 +194,8 @@ raw"a < b \leq c < d \leq e > f \leq g \leq h < i = j = k \neq l \neq m"
 @test latexraw(:(3 * (a .< b .<= c < d <= e > f <= g .<= h .< i == j .== k != l .!= m))) ==
 raw"3 \cdot \left( a < b \leq c < d \leq e > f \leq g \leq h < i = j = k \neq l \neq m \right)"
 
+@test latexraw(:(2+3 : b)) == raw"2 + 3 \mathrel{\ldotp\mkern-2.5mu\ldotp} b"
+@test latexraw(:(a:3*4)) == raw"a \mathrel{\ldotp\mkern-2.5mu\ldotp} 3 \cdot 4"
 
 #### Test the imaginary_unit keyword option
 @test latexraw(5im; imaginary_unit="\\textit{i}") == raw"5\textit{i}"


### PR DESCRIPTION
Close #315 

This makes it so ranges like `1:3` are (optionally) turned into $1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3$ rather than 
```math
\left[
\begin{array}{c}
1 \\
2 \\
3
\end{array}
\right]
```
. Step ranges like `1:2:5` do not have as standardized a math syntax, but I also include the option to have it shown as $1 \underset{2}{\mathrel{\ldotp\mkern-2.5mu\ldotp}} 5$. The kwargs `expand_ranges` and `expand_step_ranges` can disable both or one of these contractions, respectively.

When part of an expression, I have elected to not run the calculation to figure out the expanded vector, so `:(1:2:5)` always becomes $1 \underset{2}{\mathrel{\ldotp\mkern-2.5mu\ldotp}} 5$. Even if this is not standard notation, it is better than $:(1, 2, 5)$ as we had before.

Any arithmetic on the end points follows the interpretation used in Julia, so `3*1:3` (which equals `(3*1):3`) becomes $3\cdot1 \mathrel{\ldotp\mkern-2.5mu\ldotp} 3$ (no parentheses).