### PR TITLE
Add simple option to SiunitxNumberFormatter

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -84,7 +84,7 @@ You can control the formatting of numbers by passing any of the following to the
 - a formatter supplied by Latexify.jl, for example `fmt = FancyNumberFormatter(2)` (thanks to @simeonschaub). You can pass any of these formatters an integer argument which specifies how many significant digits you want.
   - `FancyNumberFormatter()` replaces the exponent notation, from `1.2e+3` to `1.2 \cdot 10^3`. 
   - `StyledNumberFormatter()` replaces the exponent notation, from `1.2e+3` to `1.2 \mathrm{e} 3`.
-  - `SiunitxNumberFormatter()` uses the `siunitx` package's `\num`, so all the formatting is offloaded on the `\LaTeX` engine. Formatting arguments can be supplied as a string to the keyword argument `format_options`. If your `siunitx` installation is version 2 or older, use the keyword argument `version=2` to replace `\num` by `\si`.
+  - `SiunitxNumberFormatter()` uses the `siunitx` package's `\num`, so all the formatting is offloaded on the `\LaTeX` engine. Formatting arguments can be supplied as a string to the keyword argument `format_options`. If your `siunitx` installation is version 2 or older, use the keyword argument `version=2` to replace `\num` by `\si`. A boolean argument `simple` can be used to control syntax for units. These two latter options do not change output for unitless numbers.
 
 
 

--- a/src/numberformatters.jl
+++ b/src/numberformatters.jl
@@ -50,42 +50,21 @@ FancyNumberFormatter(significant_digits, mult_symbol="\\cdot") =
 struct SiunitxNumberFormatter <: AbstractNumberFormatter
     format_options::String
     version::Int
+    simple::Bool
 end
-function SiunitxNumberFormatter(;format_options="", version=3)
+function SiunitxNumberFormatter(;format_options="", version=3, simple=false)
     if ~isempty(format_options) && (~startswith(format_options, '[') || ~endswith(format_options, ']'))
         format_options = "[$format_options]"
     end
-    SiunitxNumberFormatter(format_options, version)
+    SiunitxNumberFormatter(format_options, version, simple)
 end
 
 function (f::SiunitxNumberFormatter)(x::Number)
-    return "\\$(siunitxcommand(:number, f.version))$(f.format_options){$x}"
+    return "\\num$(f.format_options){$x}"
 end
 function (f::SiunitxNumberFormatter)(x::Vector{<:Number})
-    return "\\$(siunitxcommand(:numberlist, f.version))$(f.format_options){$(join(x,';'))}"
+    return "\\numlist$(f.format_options){$(join(x,';'))}"
 end
 function (f::SiunitxNumberFormatter)(x::AbstractRange{<:Number})
-    return "\\$(siunitxcommand(:numberrange, f.version))$(f.format_options){$(x.start)}{$(x.stop)}"
-end
-
-function siunitxcommand(purpose, version)
-    if version <= 2
-        purpose === :number && return "si"
-        purpose === :quantity && return "SI"
-        purpose === :numberrange && return "sirange"
-        purpose === :quantityrange && return "SIrange"
-        purpose === :numberlist && return "silist"
-        purpose === :quantitylist && return "SIlist"
-        purpose === :numberproduct && return "siproduct"
-        purpose === :quantityproduct && return "SIproduct"
-    end
-    purpose === :number && return "num"
-    purpose === :quantity && return "qty"
-    purpose === :numberrange && return "numrange"
-    purpose === :quantityrange && return "qtyrange"
-    purpose === :numberlist && return "numlist"
-    purpose === :quantitylist && return "qtylist"
-    purpose === :numberproduct && return "numproduct"
-    purpose === :quantityproduct && return "qtyproduct"
-    throw(ArgumentError("Purpose $purpose not implemented"))
+    return "\\numrange$(f.format_options){$(x.start)}{$(x.stop)}"
 end

--- a/test/numberformatters_test.jl
+++ b/test/numberformatters_test.jl
@@ -23,29 +23,12 @@ y = 0xf43
 @test StyledNumberFormatter()(y) == FancyNumberFormatter()(y) == "\\mathtt{0x0f43}"
 
 @test SiunitxNumberFormatter()(x) == "\\num{-2.34728979e8}"
-@test SiunitxNumberFormatter(version=2)(x) == "\\si{-2.34728979e8}"
+@test SiunitxNumberFormatter(version=2)(x) == "\\num{-2.34728979e8}"
 @test SiunitxNumberFormatter(format_options="something")(x) == "\\num[something]{-2.34728979e8}"
 @test SiunitxNumberFormatter(format_options="[something]")(x) == "\\num[something]{-2.34728979e8}"
 
 @test SiunitxNumberFormatter()([1,2,4]) == "\\numlist{1;2;4}"
 @test SiunitxNumberFormatter()(1:4) == "\\numrange{1}{4}"
 
-@test Latexify.siunitxcommand(:number, 2) == "si"
-@test Latexify.siunitxcommand(:quantity, 2) == "SI"
-@test Latexify.siunitxcommand(:numberrange, 2) == "sirange"
-@test Latexify.siunitxcommand(:quantityrange, 2) == "SIrange"
-@test Latexify.siunitxcommand(:numberlist, 2) == "silist"
-@test Latexify.siunitxcommand(:quantitylist, 2) == "SIlist"
-@test Latexify.siunitxcommand(:numberproduct, 2) == "siproduct"
-@test Latexify.siunitxcommand(:quantityproduct, 2) == "SIproduct"
-
-@test Latexify.siunitxcommand(:number, 3) == "num"
-@test Latexify.siunitxcommand(:quantity, 3) == "qty"
-@test Latexify.siunitxcommand(:numberrange, 3) == "numrange"
-@test Latexify.siunitxcommand(:quantityrange, 3) == "qtyrange"
-@test Latexify.siunitxcommand(:numberlist, 3) == "numlist"
-@test Latexify.siunitxcommand(:quantitylist, 3) == "qtylist"
-@test Latexify.siunitxcommand(:numberproduct, 3) == "numproduct"
-@test Latexify.siunitxcommand(:quantityproduct, 3) == "qtyproduct"
-
-@test_throws ArgumentError Latexify.siunitxcommand(:nonsense, 1)
+@test !SiunitxNumberFormatter().simple
+@test SiunitxNumberFormatter(simple=true).simple


### PR DESCRIPTION
Having spent a bit of time implementing `SiunitxNumberFormatter` support in `UnitfulLatexify`, I realized
* I needed a `simple` flag.
* Any use of `\si`, `\SI`, `\qty` or `\unit` in `Latexify` (base) is incorrect.

