### PR TITLE
Add kwargs for flags for all command line calls

### DIFF
--- a/ext/TectonicExt.jl
+++ b/ext/TectonicExt.jl
@@ -4,8 +4,8 @@ import Latexify.render, Latexify._compile
 isdefined(Base, :get_extension) ? (using tectonic_jll) : (using ..tectonic_jll)
 __precompile__(false)
 
-function render(s::LaTeXString, ::MIME"application/pdf"; use_tectonic=true, kw...)
-    use_tectonic && return _compile(s, `$(tectonic()) --keep-logs main.tex`, "pdf"; kw...)
-    return _compile(s, `lualatex --interaction=batchmode main.tex`, "pdf"; kw...)
+function render(s::LaTeXString, ::MIME"application/pdf"; use_tectonic=true, tectonic_flags="", lualatex_flags="", kw...)
+    use_tectonic && return _compile(s, `$(tectonic()) --keep-logs $tectonic_flags main.tex`, "pdf"; kw...)
+    return _compile(s, `lualatex --interaction=batchmode $lualatex_flags main.tex`, "pdf"; kw...)
 end
 end


### PR DESCRIPTION
This is a rudimentary attempt at dealing with #339 so that I can improve docs in https://github.com/JuliaPhysics/Unitful.jl/pull/795 so that I can eventually fix https://github.com/JuliaPlots/Plots.jl/issues/5093.

Basic idea is that `render` gets some new kwargs: `ghostscript_flags`, `dvipng_flags`, `tectonic_flags`, `lualatex_flags`, `dvilualatex_flags`. Since there is already a slurped `kw...` in all of the methods, I don't think this is too disruptive.

`ghostscript_flags` and `dvipng_flags` have default values, related to rastering. All of the other flag kwargs default to empty strings.