### PR TITLE
Indexing into literal arrays

### DIFF
--- a/src/latexoperation.jl
+++ b/src/latexoperation.jl
@@ -311,6 +311,9 @@ function operator_name(ex::Expr; kwargs...)
         error("I don't know what this is")
     end
 end
+function operator_name(str::LaTeXString; kwargs...)
+    return str
+end
 
 """
     precedence(op)

--- a/test/latexraw_test.jl
+++ b/test/latexraw_test.jl
@@ -41,6 +41,16 @@ raw"$a = \left[
 @test latexify(:(u[1][1]); index = :bracket) == raw"$u\left[1\right]\left[1\right]$"
 @test latexify(:(u[1][1]); index = :subscript) == raw"$\left( u_{1} \right)_{1}$"
 @test latexify(:(u_x[1][1]); index=:subscript, snakecase=true) == raw"$\left( u\_x_{1} \right)_{1}$"
+@test latexify(:([1 2 3][2]); index=:bracket) == replace(raw"""$\left[
+\begin{array}{ccc}
+1 & 2 & 3 \\
+\end{array}
+\right]\left[2\right]$""", "\r\n"=>"\n")
+@test latexify(:([1 2 3][2]); index=:subscript) == replace(raw"""$\left[
+\begin{array}{ccc}
+1 & 2 & 3 \\
+\end{array}
+\right]_{2}$""", "\r\n"=>"\n")
 
 array_test = [ex, str]
 @test all(latexraw.(array_test) .== desired_output)


### PR DESCRIPTION
`latexify(:([1 2 3][2]); index=:subscript)` used to error, now gives 
```math
\left[
\begin{array}{ccc}
1 & 2 & 3 \\
\end{array}
\right]_{2}
```

closes #350 