### PR TITLE
Replace polyfill.io with Cloudflare's mirror

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -120,7 +120,7 @@ function html_wrap(s::LaTeXString; scale=1.1, kwargs...)
             };
         </script>
         <script src="/js/mathjax/tex-chtml.js" id="MathJax-script" async></script>
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+        <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
         """
     return import_str * s.s


### PR DESCRIPTION
In 2024 `polyfill.io` changed owner and was observed serving malware.
At the moment the resource linked here seems not to be accessible  (using `wget`) and it only results in a login prompt for `polyfill.io` when displaying the HTML (harmless as far I can tell, but not my expertise edit: actually not harmless and done on purpose https://cipherssecurity.com/polyfill-io-login-prompts-toshiba-muji/).

In this PR I have replaced `polyfill.io` with Cloudflare's mirror
https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/